### PR TITLE
release: prepare v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-08-23
+
+### Fixed
+
+- 展开的 Todo、流式状态与消息流末尾现在会为官方 Composer 的动态高度预留空间，不再被底部输入区遮挡。
+- Chat 锚点恢复、`scrollIntoView` 与浏览器焦点滚动会停在 Composer 上方，并保持目标消息可见。
+
 ## [0.1.2] - 2026-08-21
 
 ### Changed
@@ -48,7 +55,8 @@
 - 提供 13 个 Oh Story 小说 Skills、7 个专业 Roles 与 10 个 Drama Skills。
 - 提供文件树、Markdown/JSONL 编辑预览与官方 DSH Chat 同屏的三栏工作台。
 
-[Unreleased]: https://github.com/worldwonderer/oh-story-dsh/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/worldwonderer/oh-story-dsh/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/worldwonderer/oh-story-dsh/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/worldwonderer/oh-story-dsh/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/worldwonderer/oh-story-dsh/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/worldwonderer/oh-story-dsh/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@
 **1. 安装插件并启动 DSH Web**
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add @oh-story/dsh@0.1.2
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add @oh-story/dsh@0.1.3
 npx -y @deepseek-ai/dsh@0.1.1-rc.1 web
 ```
 
 也可以直接安装 GitHub Release 中经过同一套测试的预构建包：
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add https://github.com/worldwonderer/oh-story-dsh/releases/download/v0.1.2/oh-story-dsh-0.1.2.tgz
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add https://github.com/worldwonderer/oh-story-dsh/releases/download/v0.1.3/oh-story-dsh-0.1.3.tgz
 npx -y @deepseek-ai/dsh@0.1.1-rc.1 web
 ```
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,7 +43,7 @@ safely re-run.
 Do not announce a release until the registry reports the exact version:
 
 ```bash
-VERSION=0.1.2
+VERSION=0.1.3
 npm view "@oh-story/dsh@$VERSION" version dist.integrity
 npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add "@oh-story/dsh@$VERSION"
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-story-dsh",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "A DSH plugin for fiction and short-drama production, powered by Oh Story and Drama Skills",
   "license": "MIT",

--- a/packages/dsh-plugin/README.md
+++ b/packages/dsh-plugin/README.md
@@ -18,14 +18,14 @@
 ## 安装
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add @oh-story/dsh@0.1.2
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add @oh-story/dsh@0.1.3
 npx -y @deepseek-ai/dsh@0.1.1-rc.1 web
 ```
 
 也可以直接安装 GitHub Release 中的预构建包：
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add https://github.com/worldwonderer/oh-story-dsh/releases/download/v0.1.2/oh-story-dsh-0.1.2.tgz
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add https://github.com/worldwonderer/oh-story-dsh/releases/download/v0.1.3/oh-story-dsh-0.1.3.tgz
 npx -y @deepseek-ai/dsh@0.1.1-rc.1 web
 ```
 

--- a/packages/dsh-plugin/package.json
+++ b/packages/dsh-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-story/dsh",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A DSH plugin for fiction and short-drama production",
   "keywords": [
     "deepseek-harness",


### PR DESCRIPTION
## 变更内容

- 将根项目与 `@oh-story/dsh` 版本更新到 `0.1.3`。
- 更新 README、包内 README 与发布文档的安装示例。
- 记录 `v0.1.2` 之后的 Composer 遮挡与 Chat 锚点修复。

## 发布范围

- 展开的 Todo、流式状态与消息流末尾为官方 Composer 的动态高度预留空间。
- Chat 锚点恢复、`scrollIntoView` 与浏览器焦点滚动保持目标消息可见。

## 验证

- `CI=true pnpm verify:release`
- 9 个 Vitest 文件 / 34 个测试通过
- packaged DSH Web + 真实 Chrome 集成通过
- `pnpm pack:release`
- tarball manifest：`@oh-story/dsh@0.1.3`
- 本地 tarball SHA-256：`bf055b9d287281e4784612d60bc497ed418f7b89a874002cde76bf93c2b513f5`
