### PR TITLE
[codex] 修复 oh_story_role 子代理注入上下文

### DIFF
--- a/packages/dsh-plugin/src/index.ts
+++ b/packages/dsh-plugin/src/index.ts
@@ -12,7 +12,7 @@ import { assertTrustedWorkspaceAuthority } from "./workspace-request-trust.js";
 
 export { createDramaSkillProvider, createOhStorySkillProvider, parseBundledSkill } from "./skill-provider.js";
 export { OH_STORY_ROLE_NAMES, loadBundledRole } from "./role-provider.js";
-export { createOhStoryRoleTool, OH_STORY_ROLE_TOOL_NAME, registerOhStoryRoleTool, roleToolFilter } from "./role-tool.js";
+export { createOhStoryRoleTool, OH_STORY_ROLE_TOOL_NAME, registerOhStoryRoleTool, roleToolFilter, type OhStoryRoleSubagents } from "./role-tool.js";
 export { registerWorkspaceRoute } from "./workspace-route.js";
 export { registerOhStoryHooks } from "./native-hooks.js";
 

--- a/packages/dsh-plugin/src/role-tool.ts
+++ b/packages/dsh-plugin/src/role-tool.ts
@@ -1,10 +1,12 @@
 import type { Context } from "@deepseek-ai/cordis";
 import type { ContentBlock } from "@deepseek-ai/dsh-llm";
 import type { JsonValue } from "@deepseek-ai/dsh-session";
+import type { SubagentRuntime } from "@deepseek-ai/dsh-subagent";
 import { defineTool, type ToolDefinition } from "@deepseek-ai/dsh-tools";
 import { OH_STORY_ROLE_NAMES, loadBundledRole, type OhStoryRoleName } from "./role-provider.js";
 
 export const OH_STORY_ROLE_TOOL_NAME = "oh_story_role";
+export type OhStoryRoleSubagents = Pick<SubagentRuntime, "start">;
 
 const roleTools: Readonly<Record<OhStoryRoleName, readonly string[]>> = {
   "chapter-extractor": ["read", "glob", "grep"],
@@ -24,7 +26,7 @@ function resultText(output: readonly ContentBlock[]): string {
   return output.map((block) => block.type === "text" ? block.text : JSON.stringify(block)).join("\n");
 }
 
-export async function createOhStoryRoleTool(): Promise<ToolDefinition> {
+export async function createOhStoryRoleTool(subagents?: OhStoryRoleSubagents): Promise<ToolDefinition> {
   const personas = new Map<OhStoryRoleName, string>();
   await Promise.all(OH_STORY_ROLE_NAMES.map(async (role) => {
     personas.set(role, await loadBundledRole(role, undefined, "native-tools"));
@@ -64,7 +66,9 @@ export async function createOhStoryRoleTool(): Promise<ToolDefinition> {
       if (persona === undefined) throw new Error(`Oh Story Role ${args.role} is not bundled.`);
       const allowed = roleToolFilter(args.role).allow.filter((name) =>
         exec.agent?.ctx.tools.get(name, exec.agent) !== undefined);
-      const run = await exec.agent.ctx.subagents.start("spawn", {
+      const runtime = subagents ?? exec.agent.ctx.get("subagents");
+      if (runtime === undefined) throw new Error("oh_story_role requires the DSH subagent runtime.");
+      const run = await runtime.start("spawn", {
         label: `oh-story:${args.role}`,
         prompt: [{ type: "text", text: args.prompt }],
         parent: exec.agent,
@@ -91,7 +95,7 @@ export async function createOhStoryRoleTool(): Promise<ToolDefinition> {
 }
 
 export async function registerOhStoryRoleTool(context: Context): Promise<void> {
-  const definition = await createOhStoryRoleTool();
+  const definition = await createOhStoryRoleTool(context.subagents);
   let dispose: (() => void) | undefined;
   const mount = (): void => { dispose ??= context.tools.register(definition); };
   const unmount = (): void => { dispose?.(); dispose = undefined; };

--- a/packages/dsh-plugin/tests/role-tool.test.ts
+++ b/packages/dsh-plugin/tests/role-tool.test.ts
@@ -1,7 +1,13 @@
+import { Context } from "@deepseek-ai/cordis";
 import type { Agent } from "@deepseek-ai/dsh-agent";
-import type { ToolRunContext } from "@deepseek-ai/dsh-tools";
+import type { SubagentRuntime } from "@deepseek-ai/dsh-subagent";
+import type { ToolDefinition, ToolRunContext, ToolRuntime } from "@deepseek-ai/dsh-tools";
 import { describe, expect, it, vi } from "vitest";
-import { createOhStoryRoleTool, OH_STORY_ROLE_TOOL_NAME, roleToolFilter } from "../src/role-tool.js";
+import { createOhStoryRoleTool, OH_STORY_ROLE_TOOL_NAME, registerOhStoryRoleTool, roleToolFilter, type OhStoryRoleSubagents } from "../src/role-tool.js";
+
+function roleSubagents(start: unknown): OhStoryRoleSubagents {
+  return { start } as unknown as OhStoryRoleSubagents;
+}
 
 describe("native Oh Story Role tool", () => {
   it("exposes all seven upstream personas through one DSH tool schema", async () => {
@@ -29,13 +35,12 @@ describe("native Oh Story Role tool", () => {
     }));
     const agent = {
       ctx: {
-        subagents: { start },
         tools: { get: vi.fn(() => ({})) }
       }
     } as unknown as Agent;
     const signal = new AbortController().signal;
     const callId = "call-1" as ToolRunContext["callId"];
-    const tool = await createOhStoryRoleTool();
+    const tool = await createOhStoryRoleTool(roleSubagents(start));
     const execute = tool.execute as (args: { readonly role: "narrative-writer"; readonly prompt: string }, exec: ToolRunContext) => Promise<unknown>;
     const result = await execute({ role: "narrative-writer", prompt: "根据给定材料起草一段正文" }, {
       agent,
@@ -60,6 +65,81 @@ describe("native Oh Story Role tool", () => {
     expect(dispose).toHaveBeenCalledOnce();
   });
 
+  it("starts roles through the plugin subagent runtime when the Agent context does not inject it", async () => {
+    const root = new Context();
+    const dispose = vi.fn(async () => {});
+    const start = vi.fn(async () => ({
+      id: "role-run-scoped",
+      result: Promise.resolve({
+        output: [{ type: "text", text: "架构结果" }],
+        stopReason: "completed" as const
+      }),
+      dispose
+    }));
+    let definition: ToolDefinition | undefined;
+    let agentContext: Context | undefined;
+
+    await root.plugin({
+      name: "tools-provider",
+      apply(context) {
+        context.provide("tools", {
+          register(value: ToolDefinition) {
+            definition = value;
+            return () => {};
+          },
+          get: vi.fn(() => ({}))
+        } as unknown as ToolRuntime);
+      }
+    });
+    await root.plugin({
+      name: "subagents-provider",
+      apply(context) {
+        context.provide("subagents", {
+          getProvider: vi.fn((name: string) => name === "spawn" ? { name } : undefined),
+          start
+        } as unknown as SubagentRuntime);
+      }
+    });
+    await root.plugin({
+      name: "agent-scope",
+      inject: ["tools"],
+      apply(context) {
+        agentContext = context;
+      }
+    });
+    await root.plugin({
+      name: "oh-story-test",
+      inject: ["tools", "subagents"],
+      apply: registerOhStoryRoleTool
+    });
+
+    try {
+      if (definition === undefined || agentContext === undefined) {
+        throw new Error("test services did not initialize");
+      }
+      const agent = { ctx: agentContext } as unknown as Agent;
+      const callId = "call-scoped" as ToolRunContext["callId"];
+      const execute = definition.execute as (args: { readonly role: "story-architect"; readonly prompt: string }, exec: ToolRunContext) => Promise<unknown>;
+      const result = await execute({ role: "story-architect", prompt: "检查故事架构" }, {
+        agent,
+        signal: new AbortController().signal,
+        callId,
+        rootCallId: callId,
+        name: OH_STORY_ROLE_TOOL_NAME,
+        arguments: {},
+        token: Symbol("tool") as ToolRunContext["token"],
+        deferContext: vi.fn(),
+        concludeTurn: vi.fn()
+      });
+
+      expect(result).toMatchObject({ role: "story-architect", runId: "role-run-scoped" });
+      expect(start).toHaveBeenCalledOnce();
+      expect(dispose).toHaveBeenCalledOnce();
+    } finally {
+      await root.fiber.dispose();
+    }
+  });
+
   it("fails closed and still disposes an incomplete role run", async () => {
     const dispose = vi.fn(async () => {});
     const start = vi.fn(async () => ({
@@ -69,12 +149,11 @@ describe("native Oh Story Role tool", () => {
     }));
     const agent = {
       ctx: {
-        subagents: { start },
         tools: { get: vi.fn(() => undefined) }
       }
     } as unknown as Agent;
     const callId = "call-2" as ToolRunContext["callId"];
-    const tool = await createOhStoryRoleTool();
+    const tool = await createOhStoryRoleTool(roleSubagents(start));
     const execute = tool.execute as (args: { readonly role: "story-explorer"; readonly prompt: string }, exec: ToolRunContext) => Promise<unknown>;
     await expect(execute({ role: "story-explorer", prompt: "查询伏笔" }, {
       agent,


### PR DESCRIPTION
## 问题

`oh_story_role` 执行时通过调用 Agent 的 Context 读取 `subagents` 服务。Agent Context 并未注入该服务，因此 Cordis 在角色调用开始前抛出：

```text
cannot get property "subagents" without inject
```

## 修复

- 创建角色工具时显式接收插件 Context 已注入的子代理运行时。
- 注册工具时传入 `context.subagents`，不再从 Agent Context 直接读取该服务。
- 保留 `createOhStoryRoleTool()` 无参调用的兼容路径，通过 Cordis `Context.get()` 安全解析运行时。
- 新增真实 Cordis Fiber 作用域回归测试，覆盖“插件已注入、Agent 未注入 `subagents`”的实际场景。

## 影响

小说与短剧工作流中的 `oh_story_role` 可以正常启动 `story-architect`、`story-explorer` 等内置角色，不再因 Context 注入边界错误立即失败。Agent 可见工具过滤、子任务生命周期和 Provider 增删行为保持不变。

## 验证

- `pnpm verify`
- 9 个测试文件、35 项测试全部通过
- 构建产物 Cordis 探针在 Agent Context 未注入 `subagents` 时成功返回角色结果
