### PR TITLE
test: harden framework and browser contracts

### DIFF
--- a/.github/workflows/real-provider.yml
+++ b/.github/workflows/real-provider.yml
@@ -11,34 +11,88 @@ permissions:
   contents: read
 
 jobs:
-  deepseek:
-    name: Official DeepSeek end-to-end
+  credential-preflight:
+    name: Credential preflight
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    outputs:
+      available: ${{ steps.credential.outputs.available }}
     env:
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
     steps:
-      - uses: actions/checkout@v7
       - name: Check credential availability
         id: credential
         shell: bash
         run: |
           if [[ -n "$DEEPSEEK_API_KEY" ]]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "DEEPSEEK_API_KEY is configured; the paid compatibility observation will run."
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "DEEPSEEK_API_KEY is not configured; skipping the paid real-provider test."
+            echo "DEEPSEEK_API_KEY is not configured; the paid compatibility observation will be skipped."
           fi
-      - if: steps.credential.outputs.available == 'true'
-        uses: pnpm/action-setup@v6
+
+  deepseek:
+    name: Official DeepSeek end-to-end
+    needs: credential-preflight
+    if: ${{ needs.credential-preflight.outputs.available == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
           version: 11.7.0
-      - if: steps.credential.outputs.available == 'true'
-        uses: actions/setup-node@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm
-      - if: steps.credential.outputs.available == 'true'
-        run: pnpm install --frozen-lockfile
-      - if: steps.credential.outputs.available == 'true'
-        run: pnpm test:dsh:real
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test:dsh:real
+
+  summary:
+    name: Real-provider outcome
+    needs:
+      - credential-preflight
+      - deepseek
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report execution outcome
+        env:
+          CREDENTIAL_AVAILABLE: ${{ needs.credential-preflight.outputs.available }}
+          PREFLIGHT_RESULT: ${{ needs.credential-preflight.result }}
+          REAL_PROVIDER_RESULT: ${{ needs.deepseek.result }}
+        shell: bash
+        run: |
+          if [[ "$PREFLIGHT_RESULT" != "success" ]]; then
+            outcome="PREFLIGHT_FAILED"
+            detail="The credential preflight failed, so the paid provider observation did not execute."
+          elif [[ "$CREDENTIAL_AVAILABLE" != "true" ]]; then
+            outcome="SKIPPED_NO_CREDENTIAL"
+            detail="The paid provider observation did not execute because DEEPSEEK_API_KEY is not configured. This is not a passing compatibility result."
+          elif [[ "$REAL_PROVIDER_RESULT" == "success" ]]; then
+            outcome="EXECUTED_AND_PASSED"
+            detail="The paid provider observation executed and passed."
+          elif [[ "$REAL_PROVIDER_RESULT" == "failure" ]]; then
+            outcome="EXECUTED_AND_FAILED"
+            detail="The paid provider observation executed and failed."
+          else
+            outcome="PROVIDER_JOB_NOT_COMPLETED"
+            detail="The paid provider job was skipped or cancelled after credential preflight, so no compatibility result is available."
+          fi
+
+          {
+            echo "## Real Provider: $outcome"
+            echo
+            echo "$detail"
+            echo
+            echo "The deterministic packaged Role test remains the correctness gate; this paid run is a provider-compatibility observation."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Real Provider outcome: $outcome"
+          if [[ "$outcome" != "EXECUTED_AND_PASSED" ]]; then
+            echo "Only an executed and passing provider observation is a successful workflow outcome." >&2
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,12 @@ pnpm install --frozen-lockfile
 
 ```bash
 pnpm verify          # 静态检查、类型、资产完整性、边界、单测与构建
-pnpm test:dsh        # 打包并安装到隔离的官方 DSH Web，验证 Session、Skills 与 UI
+pnpm test:contract   # 使用真实 Cordis Context/Fiber 验证跨作用域服务契约
+pnpm test:dsh        # 打包并安装到隔离的官方 DSH Web，验证 Session、Skills、Role 与 UI
 pnpm verify:release  # 发布门禁：verify + 原生 DSH Web 集成测试
 ```
 
-真实模型链路不会进入普通 Pull Request CI。需要发布前验证时，通过一次性环境变量或仅包含 Key 的临时文件运行：
+确定性的 packaged DSH 测试包含 Role 调用，是代码正确性的发布门禁。真实模型链路不会进入普通 Pull Request CI；它受模型、服务端和网络波动影响，只作为 provider 兼容性观察。需要发布前观察时，通过一次性环境变量或仅包含 Key 的临时文件运行：
 
 ```bash
 DEEPSEEK_API_KEY_FILE=/path/to/key pnpm test:dsh:real
@@ -49,14 +50,14 @@ pnpm assets:check
 - `CI / Quality gate`：Ubuntu 上执行完整确定性门禁 `pnpm verify`。
 - `CI / Portability`：macOS 与 Windows 执行类型、资产、单测与构建，锁定跨平台路径行为。
 - `CI / Packaged DSH Web integration`：构建 tarball、安装到官方 DSH Web，并用 Chrome 验证能力目录、工作区安全与三栏 UI。
-- `Real Provider`：手动工作流；仅在仓库配置 `DEEPSEEK_API_KEY` Secret 时运行付费真实模型链路。
+- `Real Provider`：手动兼容性观察；凭据预检与真实测试是独立 Job。配置 `DEEPSEEK_API_KEY` 时真实测试显示 executed，未配置时真实测试 Job 显示 skipped，汇总区分 `EXECUTED_AND_PASSED`、`EXECUTED_AND_FAILED`、`SKIPPED_NO_CREDENTIAL`、`PREFLIGHT_FAILED` 与 `PROVIDER_JOB_NOT_COMPLETED`。只有 `EXECUTED_AND_PASSED` 会让工作流成功；其余状态都不会产生绿色兼容性结论。
 - `Release`：Tag 或手动触发发布门禁；`v*` Tag 会把同一份 `.tgz` 发布到 GitHub Release 与 npm。
 
 ## 发布检查
 
 1. 更新版本、安装示例与 `CHANGELOG.md`。
 2. 运行 `pnpm verify:release`。
-3. 运行 `pnpm test:dsh:real` 并确认项目摘要未改变、凭据未出现在日志中。
+3. 需要观察官方 provider 兼容性时，运行 `pnpm test:dsh:real`，并确认结果是 executed and passed、项目摘要未改变、凭据未出现在日志中；缺少凭据导致的 skipped 不能记作 passed，也不替代第 2 步的确定性 correctness gate。
 4. 运行 `DEEPSEEK_API_KEY=... pnpm demo`，通过真实 DeepSeek 会话一次性重新生成并检查两张 README 演示图。
 5. 运行 `pnpm pack:release` 并检查 tarball。
 6. 按 [`docs/RELEASING.md`](docs/RELEASING.md) 创建与包版本一致的 Tag，由工作流执行正式发布。

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,18 +1,21 @@
 # Validation
 
-Target: DeepSeek Harness `0.1.1-rc.1` · validated 2026-08-21.
+Target: DeepSeek Harness `0.1.1-rc.1` · validated 2026-08-23.
 
 ## Test architecture
 
 | Layer | Command | Coverage |
 | --- | --- | --- |
 | Deterministic quality gate | `pnpm verify` | ESLint, TypeScript, pinned asset hashes/catalogs, DSH boundary audit, unit/component tests, Host/Browser build |
+| Cordis Context contracts | `pnpm test:contract` | Real Context/Fiber/provide/inject topology for cross-scope service access; leaf runtimes remain deterministic fakes |
 | Cross-platform gate | `pnpm verify:portable` | Type, asset, unit and build behavior on macOS and Windows |
-| Packaged DSH integration | `pnpm test:dsh` | Build, npm tarball, profile installation, official DSH Web startup, Session APIs, skill catalog, workspace routes and Chrome UI |
-| Real provider | `pnpm test:dsh:real` | Official DeepSeek model, durable Agent completion, Oh Story Role calls, fiction review, short-drama review, read-only project digest and credential redaction |
+| Packaged DSH integration | `pnpm test:dsh` | Deterministic correctness gate for build, npm tarball, profile installation, official DSH Web startup, Session APIs, skill catalog, workspace routes, Role execution and Chrome UI |
+| Real provider | `pnpm test:dsh:real` | Paid provider-compatibility observation for the official DeepSeek model, durable Agent completion, Oh Story Role calls, fiction review, short-drama review, read-only project digest and credential redaction |
 | Release candidate | `pnpm verify:release` | Deterministic gate plus packaged DSH integration before tarball creation |
 
-The paid real-provider layer is intentionally excluded from Pull Request CI. It is available as a manual GitHub Actions workflow and requires the repository Secret `DEEPSEEK_API_KEY`.
+The deterministic packaged Role path is part of the correctness gate. The paid real-provider layer is intentionally excluded from Pull Request CI because model, provider and network behavior are not deterministic. It is available as a manual GitHub Actions compatibility observation and requires the repository Secret `DEEPSEEK_API_KEY`; a credential-based skip is not a passing provider result.
+
+`pnpm test:contract` is the focused developer entry point. The same `*.contract.test.ts` files are discovered by `pnpm verify`, so they remain mandatory in the normal Pull Request quality gate.
 
 ## Automated coverage
 
@@ -21,18 +24,27 @@ The paid real-provider layer is intentionally excluded from Pull Request CI. It 
 | Capability catalog | Native DSH Session exposes 13 Oh Story Skills and 10 Drama Skills |
 | Upstream integrity | Both knowledge manifests verify pinned commits, catalogs and every bundled file hash |
 | Plugin boundary | Host bundle and source audit keep all DSH imports inside `@oh-story/dsh` |
-| Workspace safety | Tests cover same-origin/Host trust, canonical paths, traversal, absolute paths and symbolic-link escape |
+| Workspace safety | Unit tests cover Host/Origin/Fetch Metadata trust, while the packaged route rejects traversal and exercises session-scoped reads plus atomic writes; child-session, absolute-path and symbolic-link negative cases remain follow-up contracts |
 | Editor concurrency | Versioned GET/PUT rejects stale saves; Chrome edits, saves, rereads and restores a real workspace file |
 | File following | Tests cover DSH Step location data, nested running calls, streamed write/edit previews, creative path classification and workbench switching |
 | Markdown rendering | Component tests cover tables, task lists, fenced code, inline formatting, safe links and inert raw HTML |
 | JSONL rendering | Component tests cover typed record summaries, source line numbers, scalar records and per-line parse failures |
 | Three-column layout | Native DSH Chrome smoke checks ordered tree/editor/Chat geometry and minimum usable widths |
-| Composer stability | Scroll regression confirms the official Composer remains fixed inside the Chat column |
+| Composer stability | Browser interaction contracts run `scrollIntoView()` and verify dynamic Composer clearance in wide, medium and 500 px compact layouts |
 | Dual workbench | Native smoke switches 小说/短剧 and opens Markdown and JSONL preview/source modes |
-| Roles and hooks | Tests cover Role catalog, DSH child-Agent invocation and novel mutation guards |
+| Roles and hooks | Real Cordis Fiber contracts cover plugin-runtime capture, `Context.get()` fallback and missing-runtime failure; packaged DSH deterministically completes one child-Agent Role invocation |
 | Package contents | Build and pack include both pinned knowledge sets, package metadata and license while omitting source tests and the standalone Drama Dashboard |
 
-Current deterministic result: 9 test files and 34 tests passing.
+The gate discovers all `*.test.ts` and `*.contract.test.ts` files. Coverage claims below are tied to executable behavior, not a manually maintained test-count snapshot.
+
+## Contract evidence matrix
+
+| Product contract | Deterministic evidence required on every PR | Credentialed observation |
+| --- | --- | --- |
+| `oh_story_role` service scope | Real Cordis Fiber contract tests plus packaged parent Agent → Role child → parent result flow | Official DeepSeek model follows the complete review workflow |
+| Chat anchor clearance | Chrome performs `scrollIntoView({ block: "end" })` in wide, medium and compact layouts and checks the target remains above the Composer | None; provider behavior is irrelevant |
+| Workspace and mutation hooks | Unit tests resolve named Agent services; packaged DSH exercises Session routes and native tool execution | Real projects remain read-only during review |
+| Provider compatibility | Not used as deterministic correctness evidence | The Real Provider workflow must report `EXECUTED_AND_PASSED`; `SKIPPED_NO_CREDENTIAL` is not a pass |
 
 ## Native DSH Web audit
 
@@ -43,9 +55,10 @@ Current deterministic result: 9 test files and 34 tests passing.
 - invalid project metadata isolation without taking down the workspace;
 - published Browser module and official UI slot registrations;
 - a real DSH Agent `write` tool call, incremental editor content, authoritative disk reconciliation and official tool-file navigation;
+- a deterministic `oh_story_role` call that starts a packaged `story-explorer` child, returns its result to the parent and completes the parent turn;
 - 小说/短剧 navigation, recursive project directories, Markdown structure and JSONL structured rendering;
 - blank-session mounting, Session-switch draft recovery, source editing, conflict isolation and saved-state behavior;
-- ordered tree/editor/Chat geometry at desktop and 500 px widths, plus a Composer that remains fixed during long-message scrolling.
+- ordered tree/editor/Chat geometry at desktop and 500 px widths, a Composer that remains fixed during long-message scrolling, and anchor clearance in wide, medium and compact layouts.
 
 The same audited surface generates the README demos through `pnpm demo` (both), `pnpm demo:story`, or `pnpm demo:drama`. Demo commands require `DEEPSEEK_API_KEY`, use the real `deepseek-official` provider, wait for successful assistant turns, collapse the DSH navigation rail, and record the complete tree/editor/Chat surface. The API key is process-only and is redacted from captured failure logs.
 
@@ -64,13 +77,14 @@ Event totals are observations, not fixed assertions.
 ## CI workflows
 
 - `.github/workflows/ci.yml`: Ubuntu quality gate, macOS/Windows portability, then packaged DSH Web integration.
-- `.github/workflows/real-provider.yml`: manual paid real-provider test; cleanly skips when the Secret is absent.
+- `.github/workflows/real-provider.yml`: manual paid compatibility observation with separate credential-preflight and real-test jobs. The always-running summary distinguishes `EXECUTED_AND_PASSED`, `EXECUTED_AND_FAILED`, `SKIPPED_NO_CREDENTIAL`, `PREFLIGHT_FAILED` and `PROVIDER_JOB_NOT_COMPLETED`. Only `EXECUTED_AND_PASSED` succeeds; missing credentials, preflight failures, cancellations and abnormal skips deliberately fail the workflow instead of producing a green non-result.
 - `.github/workflows/release.yml`: tagged release gate, `.tgz` artifact upload, GitHub Release creation and npm publication with provenance.
 
 ## Commands
 
 ```bash
 pnpm verify
+pnpm test:contract
 pnpm test:dsh
 pnpm verify:release
 DEEPSEEK_API_KEY_FILE=/path/to/key pnpm test:dsh:real

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint . --max-warnings=0",
     "test": "pnpm test:unit",
     "test:unit": "pnpm -r --if-present test",
+    "test:contract": "pnpm -r --if-present test:contract",
     "test:dsh": "pnpm test:dsh:native",
     "test:dsh:native": "tsx scripts/native-dsh-smoke.ts",
     "test:dsh:real": "tsx scripts/native-dsh-real.ts",

--- a/packages/dsh-plugin/package.json
+++ b/packages/dsh-plugin/package.json
@@ -66,7 +66,8 @@
     "build": "tsx ../../scripts/build-dsh-plugin.ts && tsc -p tsconfig.build.json",
     "prepack": "pnpm build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:contract": "vitest run contract"
   },
   "license": "MIT",
   "peerDependencies": {

--- a/packages/dsh-plugin/tests/native-hooks.test.ts
+++ b/packages/dsh-plugin/tests/native-hooks.test.ts
@@ -84,14 +84,16 @@ describe("native DSH prose guards", () => {
   it("preserves DSH's downstream permission decision instead of forcing ask", async () => {
     const root = await project();
     const fs = localDshFs();
+    const get = vi.fn((name: string) => name === "fs" ? fs : undefined);
     const exec = {
       name: "write",
       arguments: { file_path: "正文/第002章.md" },
-      agent: { session: { header: { cwd: root } }, ctx: { get: () => fs } },
+      agent: { session: { header: { cwd: root } }, ctx: { get } },
       signal: new AbortController().signal
     } as unknown as ToolExecution;
     await expect(decideStoryMutation(exec, async () => ({ kind: "allow" })))
       .resolves.toEqual({ kind: "allow" });
+    expect(get).toHaveBeenCalledWith("fs");
   });
 
   it("does not impose long-form guards on a plain short-story workspace", async () => {
@@ -127,14 +129,16 @@ describe("native DSH prose guards", () => {
         }
       }])
     } as StoryFileSystem;
+    const get = vi.fn((name: string) => name === "fs" ? fs : undefined);
     const exec = {
       name: "write",
       arguments: { file_path: "正文/第002章.md" },
-      agent: { session: { header: { cwd: "/virtual-story" } }, ctx: { get: () => fs } },
+      agent: { session: { header: { cwd: "/virtual-story" } }, ctx: { get } },
       signal: new AbortController().signal
     } as unknown as ToolExecution;
 
     await expect(decideStoryMutation(exec, async () => ({ kind: "allow" }))).resolves.toEqual({ kind: "allow" });
+    expect(get).toHaveBeenCalledWith("fs");
     expect(calls).toContain("/virtual-story/追踪/_tracking-state.json");
   });
 });

--- a/packages/dsh-plugin/tests/role-tool-context.contract.test.ts
+++ b/packages/dsh-plugin/tests/role-tool-context.contract.test.ts
@@ -1,0 +1,141 @@
+import { Context } from "@deepseek-ai/cordis";
+import type { Agent } from "@deepseek-ai/dsh-agent";
+import type { SubagentRuntime } from "@deepseek-ai/dsh-subagent";
+import type { ToolDefinition, ToolRunContext, ToolRuntime } from "@deepseek-ai/dsh-tools";
+import { describe, expect, it, vi } from "vitest";
+import { createOhStoryRoleTool, OH_STORY_ROLE_TOOL_NAME, registerOhStoryRoleTool } from "../src/role-tool.js";
+
+type RoleStart = ReturnType<typeof vi.fn>;
+
+interface RoleContextTopology {
+  readonly root: Context;
+  readonly agent: Agent;
+  readonly registeredDefinition: () => ToolDefinition | undefined;
+}
+
+function completedRoleStart(runId: string): RoleStart {
+  return vi.fn(async () => ({
+    id: runId,
+    result: Promise.resolve({
+      output: [{ type: "text", text: "架构结果" }],
+      stopReason: "completed" as const
+    }),
+    dispose: vi.fn(async () => {})
+  }));
+}
+
+async function createRoleContextTopology(start?: RoleStart): Promise<RoleContextTopology> {
+  const root = new Context();
+  let definition: ToolDefinition | undefined;
+  let agentContext: Context | undefined;
+
+  await root.plugin({
+    name: "tools-provider",
+    apply(context) {
+      context.provide("tools", {
+        register(value: ToolDefinition) {
+          definition = value;
+          return () => { definition = undefined; };
+        },
+        get: vi.fn(() => ({}))
+      } as unknown as ToolRuntime);
+    }
+  });
+  if (start !== undefined) {
+    await root.plugin({
+      name: "subagents-provider",
+      apply(context) {
+        context.provide("subagents", {
+          getProvider: vi.fn((name: string) => name === "spawn" ? { name } : undefined),
+          start
+        } as unknown as SubagentRuntime);
+      }
+    });
+  }
+  await root.plugin({
+    name: "agent-scope",
+    inject: ["tools"],
+    apply(context) {
+      agentContext = context;
+    }
+  });
+  if (agentContext === undefined) throw new Error("agent Context did not initialize");
+
+  return {
+    root,
+    agent: { ctx: agentContext } as unknown as Agent,
+    registeredDefinition: () => definition
+  };
+}
+
+function runContext(agent: Agent, id: string): ToolRunContext {
+  const callId = id as ToolRunContext["callId"];
+  return {
+    agent,
+    signal: new AbortController().signal,
+    callId,
+    rootCallId: callId,
+    name: OH_STORY_ROLE_TOOL_NAME,
+    arguments: {},
+    token: Symbol("tool") as ToolRunContext["token"],
+    deferContext: vi.fn(),
+    concludeTurn: vi.fn()
+  };
+}
+
+async function executeStoryArchitect(definition: ToolDefinition, agent: Agent, callId: string): Promise<unknown> {
+  const execute = definition.execute as (
+    args: { readonly role: "story-architect"; readonly prompt: string },
+    exec: ToolRunContext
+  ) => Promise<unknown>;
+  return execute({ role: "story-architect", prompt: "检查故事架构" }, runContext(agent, callId));
+}
+
+describe("oh_story_role Cordis Context contract", () => {
+  it("uses the plugin runtime when the Agent Fiber intentionally does not inject subagents", async () => {
+    const start = completedRoleStart("role-run-plugin");
+    const topology = await createRoleContextTopology(start);
+    try {
+      expect(() => topology.agent.ctx.subagents).toThrow('cannot get property "subagents" without inject');
+      await topology.root.plugin({
+        name: "oh-story-test",
+        inject: ["tools", "subagents"],
+        apply: registerOhStoryRoleTool
+      });
+      const definition = topology.registeredDefinition();
+      if (definition === undefined) throw new Error("role tool did not register");
+
+      await expect(executeStoryArchitect(definition, topology.agent, "call-plugin"))
+        .resolves.toMatchObject({ role: "story-architect", runId: "role-run-plugin" });
+      expect(start).toHaveBeenCalledOnce();
+    } finally {
+      await topology.root.fiber.dispose();
+    }
+  });
+
+  it("resolves the runtime with Context.get when a standalone tool has no captured runtime", async () => {
+    const start = completedRoleStart("role-run-fallback");
+    const topology = await createRoleContextTopology(start);
+    try {
+      const definition = await createOhStoryRoleTool();
+
+      await expect(executeStoryArchitect(definition, topology.agent, "call-fallback"))
+        .resolves.toMatchObject({ role: "story-architect", runId: "role-run-fallback" });
+      expect(start).toHaveBeenCalledOnce();
+    } finally {
+      await topology.root.fiber.dispose();
+    }
+  });
+
+  it("fails with the plugin contract error when no subagent runtime exists", async () => {
+    const topology = await createRoleContextTopology();
+    try {
+      const definition = await createOhStoryRoleTool();
+
+      await expect(executeStoryArchitect(definition, topology.agent, "call-missing"))
+        .rejects.toThrow("oh_story_role requires the DSH subagent runtime.");
+    } finally {
+      await topology.root.fiber.dispose();
+    }
+  });
+});

--- a/packages/dsh-plugin/tests/role-tool.test.ts
+++ b/packages/dsh-plugin/tests/role-tool.test.ts
@@ -1,9 +1,7 @@
-import { Context } from "@deepseek-ai/cordis";
 import type { Agent } from "@deepseek-ai/dsh-agent";
-import type { SubagentRuntime } from "@deepseek-ai/dsh-subagent";
-import type { ToolDefinition, ToolRunContext, ToolRuntime } from "@deepseek-ai/dsh-tools";
+import type { ToolRunContext } from "@deepseek-ai/dsh-tools";
 import { describe, expect, it, vi } from "vitest";
-import { createOhStoryRoleTool, OH_STORY_ROLE_TOOL_NAME, registerOhStoryRoleTool, roleToolFilter, type OhStoryRoleSubagents } from "../src/role-tool.js";
+import { createOhStoryRoleTool, OH_STORY_ROLE_TOOL_NAME, roleToolFilter, type OhStoryRoleSubagents } from "../src/role-tool.js";
 
 function roleSubagents(start: unknown): OhStoryRoleSubagents {
   return { start } as unknown as OhStoryRoleSubagents;
@@ -63,81 +61,6 @@ describe("native Oh Story Role tool", () => {
     }));
     expect(result).toMatchObject({ role: "narrative-writer", runId: "role-run-1" });
     expect(dispose).toHaveBeenCalledOnce();
-  });
-
-  it("starts roles through the plugin subagent runtime when the Agent context does not inject it", async () => {
-    const root = new Context();
-    const dispose = vi.fn(async () => {});
-    const start = vi.fn(async () => ({
-      id: "role-run-scoped",
-      result: Promise.resolve({
-        output: [{ type: "text", text: "架构结果" }],
-        stopReason: "completed" as const
-      }),
-      dispose
-    }));
-    let definition: ToolDefinition | undefined;
-    let agentContext: Context | undefined;
-
-    await root.plugin({
-      name: "tools-provider",
-      apply(context) {
-        context.provide("tools", {
-          register(value: ToolDefinition) {
-            definition = value;
-            return () => {};
-          },
-          get: vi.fn(() => ({}))
-        } as unknown as ToolRuntime);
-      }
-    });
-    await root.plugin({
-      name: "subagents-provider",
-      apply(context) {
-        context.provide("subagents", {
-          getProvider: vi.fn((name: string) => name === "spawn" ? { name } : undefined),
-          start
-        } as unknown as SubagentRuntime);
-      }
-    });
-    await root.plugin({
-      name: "agent-scope",
-      inject: ["tools"],
-      apply(context) {
-        agentContext = context;
-      }
-    });
-    await root.plugin({
-      name: "oh-story-test",
-      inject: ["tools", "subagents"],
-      apply: registerOhStoryRoleTool
-    });
-
-    try {
-      if (definition === undefined || agentContext === undefined) {
-        throw new Error("test services did not initialize");
-      }
-      const agent = { ctx: agentContext } as unknown as Agent;
-      const callId = "call-scoped" as ToolRunContext["callId"];
-      const execute = definition.execute as (args: { readonly role: "story-architect"; readonly prompt: string }, exec: ToolRunContext) => Promise<unknown>;
-      const result = await execute({ role: "story-architect", prompt: "检查故事架构" }, {
-        agent,
-        signal: new AbortController().signal,
-        callId,
-        rootCallId: callId,
-        name: OH_STORY_ROLE_TOOL_NAME,
-        arguments: {},
-        token: Symbol("tool") as ToolRunContext["token"],
-        deferContext: vi.fn(),
-        concludeTurn: vi.fn()
-      });
-
-      expect(result).toMatchObject({ role: "story-architect", runId: "role-run-scoped" });
-      expect(start).toHaveBeenCalledOnce();
-      expect(dispose).toHaveBeenCalledOnce();
-    } finally {
-      await root.fiber.dispose();
-    }
   });
 
   it("fails closed and still disposes an incomplete role run", async () => {

--- a/scripts/native-dsh-smoke.ts
+++ b/scripts/native-dsh-smoke.ts
@@ -5,7 +5,7 @@ import { createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { chromium, type Page } from "@playwright/test";
+import { chromium, type Locator, type Page } from "@playwright/test";
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const dshVersion = "0.1.1-rc.1";
@@ -26,6 +26,10 @@ const agentMutationContent = "# Agent 写入验证\n\n这段正文由真实 DSH 
 const agentMutationReply = "测试文件已通过 write 工具创建。";
 const todoLayoutPrompt = "TODO_LAYOUT_SMOKE：写入十一条已完成任务。";
 const todoLayoutItems = Array.from({ length: 11 }, (_, index) => ({ content: `布局任务 ${String(index + 1)}`, status: "completed" }));
+const roleSmokePrompt = "ROLE_RUNTIME_SMOKE：必须调用 oh_story_role 的 story-explorer，并返回子角色结果。";
+const roleChildPrompt = "ROLE_CHILD_SMOKE：只回复指定验证文本，不调用任何工具。";
+const roleChildReply = "ROLE_CHILD_RESULT：story-explorer 子 Agent 已完成。";
+const roleParentReply = "ROLE_PARENT_RESULT：已收到 story-explorer 子 Agent 结果。";
 
 async function captureDemoFrame(page: Page, workbench: "story" | "drama", index: number): Promise<void> {
   if (demoFramesDirectory === undefined) return;
@@ -70,10 +74,12 @@ async function freePort(): Promise<number> {
 
 interface MockDeepSeek {
   readonly baseURL: string;
+  readonly requests: string[];
   readonly server: HttpServer;
 }
 
 async function startMockDeepSeek(): Promise<MockDeepSeek> {
+  const requests: string[] = [];
   const server = createHttpServer((request, response) => {
     let body = "";
     request.on("data", (chunk: Buffer) => { body += chunk.toString("utf8"); });
@@ -94,12 +100,25 @@ async function startMockDeepSeek(): Promise<MockDeepSeek> {
       const currentTurn = JSON.stringify(messages.slice(Math.max(lastUserIndex, 0)));
       const mutationTurn = currentTurn.includes(agentMutationPrompt);
       const todoLayoutTurn = currentTurn.includes(todoLayoutPrompt);
+      const roleParentTurn = currentTurn.includes(roleSmokePrompt);
+      const roleChildTurn = serialized.includes(roleChildPrompt) && !serialized.includes(roleSmokePrompt);
       const hasToolResult = messages.slice(lastUserIndex + 1).some((message) => message.role === "tool");
       let events: string[];
-      if ((mutationTurn || todoLayoutTurn) && !hasToolResult) {
-        const tool = todoLayoutTurn
-          ? { id: "call_todo_layout", name: "todo_write", args: { todos: todoLayoutItems } }
-          : { id: "call_oh_story_write_smoke", name: "write", args: { file_path: agentMutationPath, content: agentMutationContent } };
+      if (roleChildTurn) {
+        requests.push("role-child");
+        events = [
+          JSON.stringify({ choices: [{ delta: { role: "assistant", content: null, reasoning_content: "" } }] }),
+          JSON.stringify({ choices: [{ delta: { content: roleChildReply } }] }),
+          JSON.stringify({ choices: [{ delta: { content: "" }, finish_reason: "stop" }], usage: { prompt_tokens: 12, completion_tokens: 20 } }),
+          "[DONE]"
+        ];
+      } else if ((mutationTurn || todoLayoutTurn || roleParentTurn) && !hasToolResult) {
+        const tool = roleParentTurn
+          ? { id: "call_oh_story_role_smoke", name: "oh_story_role", args: { role: "story-explorer", prompt: roleChildPrompt } }
+          : todoLayoutTurn
+            ? { id: "call_todo_layout", name: "todo_write", args: { todos: todoLayoutItems } }
+            : { id: "call_oh_story_write_smoke", name: "write", args: { file_path: agentMutationPath, content: agentMutationContent } };
+        requests.push(roleParentTurn ? "role-parent-start" : todoLayoutTurn ? "todo" : "write");
         const argumentsJson = JSON.stringify(tool.args);
         const chunks = argumentsJson.match(/.{1,14}/gu) ?? [argumentsJson];
         events = [
@@ -113,7 +132,17 @@ async function startMockDeepSeek(): Promise<MockDeepSeek> {
           "[DONE]"
         ];
       } else {
-        const content = mutationTurn ? agentMutationReply : serialized.includes(dramaProjectName) ? dramaReply : storyReply;
+        if (roleParentTurn && !serialized.includes(roleChildReply)) {
+          requests.push("role-parent-resume-missing-result");
+          response.writeHead(422, { "content-type": "application/json" }).end('{"error":"role child result was not returned to the parent"}');
+          return;
+        }
+        requests.push(roleParentTurn ? "role-parent-resume" : "other");
+        const content = roleParentTurn
+          ? roleParentReply
+          : mutationTurn
+            ? agentMutationReply
+            : serialized.includes(dramaProjectName) ? dramaReply : storyReply;
         events = [
           JSON.stringify({ choices: [{ delta: { role: "assistant", content: null, reasoning_content: "" } }] }),
           JSON.stringify({ choices: [{ delta: { content } }] }),
@@ -141,7 +170,7 @@ async function startMockDeepSeek(): Promise<MockDeepSeek> {
   });
   const address = server.address();
   if (address === null || typeof address === "string") throw new Error("Could not start the local DeepSeek fixture.");
-  return { baseURL: `http://127.0.0.1:${String(address.port)}`, server };
+  return { baseURL: `http://127.0.0.1:${String(address.port)}`, requests, server };
 }
 
 async function closeServer(server: HttpServer): Promise<void> {
@@ -184,18 +213,24 @@ async function rpc<T>(origin: string, method: string, payload: unknown): Promise
   }
 }
 
-interface HistoryEvent { readonly type: string; readonly data: unknown }
+interface HistoryEvent { readonly seq: number; readonly type: string; readonly data: unknown }
 
-async function waitForCompletedTurn(origin: string, sessionId: string): Promise<readonly HistoryEvent[]> {
+async function sessionEvents(origin: string, sessionId: string): Promise<readonly HistoryEvent[]> {
+  const history = await rpc<{ readonly events: readonly { readonly event: HistoryEvent }[] }>(origin, "session.history", { sessionId, maxMessages: 1_000 });
+  return history.events.map((entry) => entry.event);
+}
+
+async function waitForCompletedTurn(origin: string, sessionId: string, afterSeq = -1): Promise<readonly HistoryEvent[]> {
   const timeout = useRealDeepSeek ? 600_000 : 30_000;
   const deadline = Date.now() + timeout;
   while (Date.now() < deadline) {
-    const history = await rpc<{ readonly events: readonly { readonly event: HistoryEvent }[] }>(origin, "session.history", { sessionId, maxMessages: 1_000 });
-    const events = history.events.map((entry) => entry.event);
+    const events = (await sessionEvents(origin, sessionId)).filter((event) => event.seq > afterSeq);
     const end = [...events].reverse().find((event) => event.type === "turn/end");
     if (end !== undefined) {
       const reason = (end.data as { readonly reason?: { readonly kind?: string } }).reason?.kind;
-      if (reason !== "completed") throw new Error(`DSH Agent turn ended with ${String(reason)}.`);
+      if (reason !== "completed") {
+        throw new Error(`DSH Agent turn ended with ${String(reason)}: ${JSON.stringify({ end: end.data, tail: events.slice(-12).map((event) => ({ seq: event.seq, type: event.type, data: event.data })) })}`);
+      }
       if (!events.some((event) => event.type === "assistant/message")) throw new Error("DSH Agent turn has no assistant result.");
       return events;
     }
@@ -275,6 +310,37 @@ async function selectSession(page: Page, workspaceTitle: string, sessionTitle: s
   await sessionRow.click();
   await page.getByRole("treeitem", { selected: true }).filter({ hasText: sessionTitle }).first()
     .waitFor({ state: "visible", timeout: 10_000 });
+}
+
+async function assertChatAnchorContract(
+  page: Page,
+  chat: Locator,
+  scroller: Locator,
+  composer: Locator,
+  expectedLayout: "wide" | "medium" | "compact"
+): Promise<void> {
+  await page.waitForFunction((layout) => (
+    document.querySelector("[data-conversation-scroll]")?.getAttribute("data-oh-story-layout") === layout
+  ), expectedLayout);
+  const anchor = page.locator("[data-chat-flow-key]").last();
+  await anchor.evaluate(async (element) => {
+    element.scrollIntoView({ block: "end" });
+    await new Promise<void>((accept) => {
+      requestAnimationFrame(() => { requestAnimationFrame(() => { accept(); }); });
+    });
+  });
+  const [anchorBox, composerBox, chatBox, scrollPaddingBottom] = await Promise.all([
+    anchor.boundingBox(), composer.boundingBox(), chat.boundingBox(),
+    scroller.evaluate((element) => Number.parseFloat(getComputedStyle(element).scrollPaddingBottom))
+  ]);
+  const valid = anchorBox !== null && composerBox !== null && chatBox !== null
+    && anchorBox.y + anchorBox.height <= composerBox.y - 15
+    && scrollPaddingBottom >= composerBox.height + 15
+    && composerBox.x >= chatBox.x - 1
+    && composerBox.x + composerBox.width <= chatBox.x + chatBox.width + 1;
+  if (!valid) {
+    throw new Error(`Chat anchor contract failed in ${expectedLayout} layout: ${JSON.stringify({ anchorBox, composerBox, chatBox, scrollPaddingBottom })}`);
+  }
 }
 
 async function stop(child: ChildProcess): Promise<void> {
@@ -368,6 +434,41 @@ async function main(): Promise<void> {
     const dramaSessionTitle = `短剧 · ${dramaProjectName}`;
     await prepareSession(origin, storySession.sessionId, storyPrompt, storySessionTitle);
     await prepareSession(origin, dramaSession.sessionId, dramaPrompt, dramaSessionTitle);
+
+    if (!useRealDeepSeek) {
+      const previousEvents = await sessionEvents(origin, storySession.sessionId);
+      const afterSeq = previousEvents.at(-1)?.seq ?? -1;
+      await rpc(origin, "session.prompt", {
+        sessionId: storySession.sessionId,
+        mode: "queue",
+        content: [{ type: "text", text: roleSmokePrompt }]
+      });
+      const roleEvents = await waitForCompletedTurn(origin, storySession.sessionId, afterSeq);
+      const roleCalls = roleEvents.filter((event) => event.type === "tool/call")
+        .map((event) => event.data as { readonly callId?: string; readonly name?: string; readonly arguments?: unknown })
+        .filter((call) => call.name === "oh_story_role");
+      const roleResult = roleEvents.filter((event) => event.type === "tool/result")
+        .flatMap((event) => (event.data as {
+          readonly message?: { readonly content?: readonly { readonly toolCallId?: string; readonly isError?: boolean }[] };
+        }).message?.content ?? [])
+        .find((result) => result.toolCallId === roleCalls[0]?.callId);
+      let roleArguments: unknown;
+      try {
+        const value = roleCalls[0]?.arguments;
+        roleArguments = typeof value === "string" ? JSON.parse(value) as unknown : value;
+      } catch { roleArguments = undefined; }
+      const roleTrace = mockDeepSeek?.requests.filter((kind) => kind.startsWith("role-")) ?? [];
+      const serializedRoleEvents = JSON.stringify(roleEvents);
+      if (roleCalls.length !== 1
+        || (roleArguments as { readonly role?: unknown } | undefined)?.role !== "story-explorer"
+        || (roleArguments as { readonly prompt?: unknown } | undefined)?.prompt !== roleChildPrompt
+        || roleResult?.isError !== false
+        || !serializedRoleEvents.includes(roleChildReply)
+        || !serializedRoleEvents.includes(roleParentReply)
+        || JSON.stringify(roleTrace) !== JSON.stringify(["role-parent-start", "role-child", "role-parent-resume"])) {
+        throw new Error(`Packaged oh_story_role contract failed: ${JSON.stringify({ roleCalls, roleArguments, roleResult, roleTrace, eventTypes: roleEvents.map((event) => event.type), hasChildReply: serializedRoleEvents.includes(roleChildReply), hasParentReply: serializedRoleEvents.includes(roleParentReply) })}`);
+      }
+    }
 
     const storyWorkspaceResponse = await fetch(`${origin}/oh-story/workspace?sessionId=${encodeURIComponent(storySession.sessionId)}`);
     const storyWorkspacePayload = await storyWorkspaceResponse.json() as { readonly mode?: string; readonly cwd?: string; readonly files?: readonly { readonly path: string }[]; readonly shortDrama?: unknown };
@@ -845,18 +946,7 @@ async function main(): Promise<void> {
       if (await scrollerLocator.getAttribute("data-oh-story-layout") !== "wide") {
         throw new Error("Workbench did not derive its wide layout from the conversation container.");
       }
-      const anchoredChatRow = page.locator("[data-chat-flow-key]").last();
-      await anchoredChatRow.evaluate((element) => { element.scrollIntoView({ block: "end" }); });
-      await page.waitForTimeout(50);
-      const [anchoredChatBox, anchoredComposerBox, scrollPaddingBottom] = await Promise.all([
-        anchoredChatRow.boundingBox(), composerLocator.boundingBox(),
-        scrollerLocator.evaluate((element) => Number.parseFloat(getComputedStyle(element).scrollPaddingBottom))
-      ]);
-      if (anchoredChatBox === null || anchoredComposerBox === null
-        || anchoredChatBox.y + anchoredChatBox.height > anchoredComposerBox.y - 15
-        || scrollPaddingBottom < anchoredComposerBox.height + 15) {
-        throw new Error(`Chat anchor scrolled behind the official Composer: ${JSON.stringify({ anchoredChatBox, anchoredComposerBox, scrollPaddingBottom })}`);
-      }
+      await assertChatAnchorContract(page, chatLocator, scrollerLocator, composerLocator, "wide");
       const scrollViewport = await scrollerLocator.boundingBox();
       if (scrollViewport === null) throw new Error("Missing conversation scroll viewport.");
       const priorMinHeight = await chatLocator.evaluate((element) => element.style.minHeight);
@@ -908,6 +998,7 @@ async function main(): Promise<void> {
         || narrowTree.width < 100 || narrowEditor.width < 200 || narrowChat.width < 240) {
         throw new Error(`Workbench overflowed the minimum DSH center width: ${JSON.stringify({ narrowViewportWidth, narrowScroller, narrowWorkbench, narrowTree, narrowEditor, narrowChat })}`);
       }
+      await assertChatAnchorContract(page, chatLocator, scrollerLocator, composerLocator, "medium");
       await openGroup(page, "剧集");
       await openFolder(page, "EP001");
       await openFolder(page, "storyboard");
@@ -943,6 +1034,7 @@ async function main(): Promise<void> {
         || compactFileTextWidth < 32 || compactHeaderWidth < 40 || compactJsonIdWidth < 32 || pageOverflow > 1) {
         throw new Error(`500px viewport clipped the workbench or made its content unreadable: ${JSON.stringify({ compactScroller, compactBoxes, compactFileTextWidth, compactHeaderWidth, compactJsonIdWidth, pageOverflow })}`);
       }
+      await assertChatAnchorContract(page, chatLocator, scrollerLocator, composerLocator, "compact");
       await page.getByRole("tab", { name: "源码" }).click();
       const compactSource = page.getByRole("textbox", { name: compactPath });
       await compactSource.press("End");
@@ -976,13 +1068,14 @@ async function main(): Promise<void> {
       uiSlots: ["shell.overlay", "tool.call.toolview"],
       threeColumn: true,
       agentWriteStreaming: !useRealDeepSeek,
+      roleToolE2e: !useRealDeepSeek,
       atomicCasWriters: candidates.length,
       compactViewport: 500
     })}\n`);
   } catch (error) {
     const apiKey = process.env.DEEPSEEK_API_KEY;
     const redact = (value: string): string => apiKey === undefined ? value : value.replaceAll(apiKey, "[REDACTED]");
-    throw new Error(`${redact(String(error))}\nDSH logs:\n${redact(logs.join("").slice(-16_000))}`, { cause: error });
+    throw new Error(`${redact(String(error))}\nMock requests: ${JSON.stringify(mockDeepSeek?.requests ?? [])}\nDSH logs:\n${redact(logs.join("").slice(-16_000))}`, { cause: error });
   } finally {
     if (child !== undefined) await stop(child);
     if (mockDeepSeek !== undefined) await closeServer(mockDeepSeek.server);


### PR DESCRIPTION
## Summary

- add a real Cordis `Context`/Fiber contract suite for `oh_story_role`, including the missing-inject failure mode
- exercise the packaged Role flow deterministically from parent turn to child agent and back to the parent
- verify the Chat anchor with a real `scrollIntoView()` interaction in wide, medium, and compact layouts
- make paid Real Provider runs report executed, skipped-without-credential, and preflight-failed states truthfully
- document the deterministic correctness gates versus optional provider compatibility observations

This PR changes the test and validation system only; it does not change production behavior.

## Why

The fixes in PR #5 and PR #7 exposed two test-system gaps:

1. static geometry checks did not cover the actual browser scrolling behavior
2. permissive plain-object mocks hid Cordis injection boundaries

The new contracts fail against the old implementations, so these regression classes are now caught before merge.

## Verification

- `pnpm test:contract` — 3/3 passed
- `pnpm verify` — 10 files / 37 tests passed, lint/type/assets/boundary/build passed
- `pnpm test:dsh:native` — passed with `roleToolE2e: true`
- `actionlint .github/workflows/real-provider.yml` — passed
- `git diff --check` — passed

## Negative controls

- restoring direct `exec.agent.ctx.subagents` access makes the real Cordis contract and packaged Role flow fail
- removing Chat `scroll-padding-bottom` makes the wide-layout anchor contract fail
