### PR TITLE
docs: migrate repository namespace to zenstory-ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,9 @@
 - 提供 13 个 Oh Story 小说 Skills、7 个专业 Roles 与 10 个 Drama Skills。
 - 提供文件树、Markdown/JSONL 编辑预览与官方 DSH Chat 同屏的三栏工作台。
 
-[Unreleased]: https://github.com/worldwonderer/oh-story-dsh/compare/v0.1.4...HEAD
-[0.1.4]: https://github.com/worldwonderer/oh-story-dsh/compare/v0.1.3...v0.1.4
-[0.1.3]: https://github.com/worldwonderer/oh-story-dsh/compare/v0.1.2...v0.1.3
-[0.1.2]: https://github.com/worldwonderer/oh-story-dsh/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/worldwonderer/oh-story-dsh/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/worldwonderer/oh-story-dsh/releases/tag/v0.1.0
+[Unreleased]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/zenstory-ai/oh-story-dsh/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **小说与短剧创作工作台**
 
-[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) · [Oh Story](https://github.com/worldwonderer/oh-story-claudecode) · [Drama Skills](https://github.com/worldwonderer/drama-skills) · [MIT](LICENSE)
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) · [Oh Story](https://github.com/zenstory-ai/oh-story-claudecode) · [Drama Skills](https://github.com/zenstory-ai/drama-skills) · [MIT](LICENSE)
 
 </div>
 
@@ -39,8 +39,8 @@
 
 | 工作台 | 上游能力 | 主要入口 |
 | --- | --- | --- |
-| 小说 | [Oh Story 0.7.6](https://github.com/worldwonderer/oh-story-claudecode) · 13 Skills · 7 Roles | `/story`、`/story-long-write`、`/story-review` |
-| 短剧 | [Drama Skills 0.6.0](https://github.com/worldwonderer/drama-skills/releases/tag/v0.6.0) · 10 Skills | `/short-drama`、`/short-drama-write`、`/short-drama-storyboard` |
+| 小说 | [Oh Story 0.7.6](https://github.com/zenstory-ai/oh-story-claudecode) · 13 Skills · 7 Roles | `/story`、`/story-long-write`、`/story-review` |
+| 短剧 | [Drama Skills 0.6.0](https://github.com/zenstory-ai/drama-skills/releases/tag/v0.6.0) · 10 Skills | `/short-drama`、`/short-drama-write`、`/short-drama-storyboard` |
 
 ## 安装
 
@@ -56,7 +56,7 @@ npx -y @deepseek-ai/dsh@0.1.1-rc.1 web
 也可以直接安装 GitHub Release 中经过同一套测试的预构建包：
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add https://github.com/worldwonderer/oh-story-dsh/releases/download/v0.1.4/oh-story-dsh-0.1.4.tgz
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add https://github.com/zenstory-ai/oh-story-dsh/releases/download/v0.1.4/oh-story-dsh-0.1.4.tgz
 npx -y @deepseek-ai/dsh@0.1.1-rc.1 web
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Security fixes land on the latest published `@oh-story/dsh` release. Report issu
 ## Reporting a vulnerability
 
 Please do not open a public issue for a suspected vulnerability. Use GitHub's private
-[Report a vulnerability](https://github.com/worldwonderer/oh-story-dsh/security/advisories/new)
+[Report a vulnerability](https://github.com/zenstory-ai/oh-story-dsh/security/advisories/new)
 form instead. Include the DSH version, the plugin version, and a reproduction. We aim to
 acknowledge within 72 hours.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,7 +12,7 @@ release note.
 
 After the first publication, configure npm Trusted Publishing for:
 
-- repository: `worldwonderer/oh-story-dsh`
+- repository: `zenstory-ai/oh-story-dsh`
 - workflow: `release.yml`
 
 The workflow requests an OpenID Connect identity and publishes with provenance.
@@ -51,5 +51,5 @@ npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add "@oh-story/dsh@$VERS
 The GitHub Release tarball remains a registry-independent installation path:
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add "https://github.com/worldwonderer/oh-story-dsh/releases/download/v$VERSION/oh-story-dsh-$VERSION.tgz"
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add "https://github.com/zenstory-ai/oh-story-dsh/releases/download/v$VERSION/oh-story-dsh-$VERSION.tgz"
 ```

--- a/packages/dsh-plugin/README.md
+++ b/packages/dsh-plugin/README.md
@@ -1,8 +1,8 @@
 # @oh-story/dsh
 
-[GitHub](https://github.com/worldwonderer/oh-story-dsh) · [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) · [MIT](LICENSE)
+[GitHub](https://github.com/zenstory-ai/oh-story-dsh) · [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) · [MIT](LICENSE)
 
-![oh-story-dsh 小说工作台](https://raw.githubusercontent.com/worldwonderer/oh-story-dsh/main/docs/images/oh-story-dsh-demo.gif)
+![oh-story-dsh 小说工作台](https://raw.githubusercontent.com/zenstory-ai/oh-story-dsh/main/docs/images/oh-story-dsh-demo.gif)
 
 `oh-story-dsh` 是基于 DeepSeek Harness（DSH）构建的社区小说与短剧创作插件，提供：
 
@@ -25,7 +25,7 @@ npx -y @deepseek-ai/dsh@0.1.1-rc.1 web
 也可以直接安装 GitHub Release 中的预构建包：
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add https://github.com/worldwonderer/oh-story-dsh/releases/download/v0.1.4/oh-story-dsh-0.1.4.tgz
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile web add https://github.com/zenstory-ai/oh-story-dsh/releases/download/v0.1.4/oh-story-dsh-0.1.4.tgz
 npx -y @deepseek-ai/dsh@0.1.1-rc.1 web
 ```
 
@@ -37,4 +37,4 @@ Drama Skills 0.6.0 不支持把 v0.5 结构化项目原地升级为 creator-firs
 
 ## License
 
-[Changelog](https://github.com/worldwonderer/oh-story-dsh/blob/main/CHANGELOG.md) · [MIT](LICENSE)
+[Changelog](https://github.com/zenstory-ai/oh-story-dsh/blob/main/CHANGELOG.md) · [MIT](LICENSE)

--- a/packages/dsh-plugin/package.json
+++ b/packages/dsh-plugin/package.json
@@ -14,11 +14,11 @@
     "screenwriting",
     "ai-agents"
   ],
-  "homepage": "https://github.com/worldwonderer/oh-story-dsh#readme",
-  "bugs": "https://github.com/worldwonderer/oh-story-dsh/issues",
+  "homepage": "https://github.com/zenstory-ai/oh-story-dsh#readme",
+  "bugs": "https://github.com/zenstory-ai/oh-story-dsh/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/worldwonderer/oh-story-dsh.git",
+    "url": "git+https://github.com/zenstory-ai/oh-story-dsh.git",
     "directory": "packages/dsh-plugin"
   },
   "publishConfig": {

--- a/packages/knowledge/drama/manifest.json
+++ b/packages/knowledge/drama/manifest.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
   "upstream": {
-    "repository": "https://github.com/worldwonderer/drama-skills.git",
-    "commit": "7811065c171f8b0a83230bb2e0ccfe2c2b5b337a"
+    "repository": "git@github.com:zenstory-ai/drama-skills.git",
+    "commit": "db69caa238ee1dab5514589319a83f0778e6b4db"
   },
-  "generatedAt": "2026-08-23T14:48:42.386Z",
+  "generatedAt": "2026-08-24T15:28:14.083Z",
   "skills": [
     "short-drama",
     "short-drama-assets",

--- a/packages/knowledge/oh-story/manifest.json
+++ b/packages/knowledge/oh-story/manifest.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 2,
   "upstream": {
-    "repository": "git@github.com:worldwonderer/oh-story-claudecode.git",
-    "commit": "9d0bd5f5aead707ddcdcf7d5f141b237e2ac464c",
+    "repository": "git@github.com:zenstory-ai/oh-story-claudecode.git",
+    "commit": "a78f75a234f084c6b5469b301eecbea103c1ecae",
     "releaseVersion": "0.7.6",
     "agentsVersion": 25
   },
-  "generatedAt": "2026-08-23T14:45:57.000Z",
+  "generatedAt": "2026-08-24T15:28:10.874Z",
   "skills": [
     "browser-cdp",
     "story",
@@ -74,13 +74,13 @@
     },
     {
       "path": "skills/browser-cdp/SKILL.md",
-      "sha256": "b6b899779654add6e823c4580439e1960bae814284e1fd41df4273bfb46366b4",
-      "bytes": 6964
+      "sha256": "aa594fbec8ba42f0eb46458a926286c3154b9d92bfb329241efd3344dd0dda3c",
+      "bytes": 6962
     },
     {
       "path": "skills/story-cover/SKILL.md",
-      "sha256": "98902e125ace61b0059fa27f94a50608c919767a50deda3bec1818ce95b73cb5",
-      "bytes": 16284
+      "sha256": "2b3ecdd288671f8cc566a54dd13a75ec3d600d72307dc6c0d76e456760a1a6e7",
+      "bytes": 16282
     },
     {
       "path": "skills/story-cover/references/cover-styles.md",
@@ -89,8 +89,8 @@
     },
     {
       "path": "skills/story-deslop/SKILL.md",
-      "sha256": "7b767fd9cc3d3aacbc2f05d6bfd8f86da7fa04f6d77ba1fb05e66f35bfc82fab",
-      "bytes": 29421
+      "sha256": "622581a30c30c66b41ec3e76a004fef6fab51157288db08bd9793adeb1f09984",
+      "bytes": 29419
     },
     {
       "path": "skills/story-deslop/references/anti-ai-writing.md",
@@ -124,8 +124,8 @@
     },
     {
       "path": "skills/story-import/SKILL.md",
-      "sha256": "ded07fb520b5d6dfa3b94ceacf984af429c64620360bb1f211ce5418e385a405",
-      "bytes": 41904
+      "sha256": "ac8854f3447cf0b41bb1799fbb13aa2749f6bf08d099f61f64e49a3382c944d4",
+      "bytes": 41902
     },
     {
       "path": "skills/story-import/references/character-state-reverse.md",
@@ -169,8 +169,8 @@
     },
     {
       "path": "skills/story-long-analyze/SKILL.md",
-      "sha256": "6b23ee7e04c424bdb7170031106328a705eba7a541587325c0a5c51056b6fd4d",
-      "bytes": 30113
+      "sha256": "e7e5b9e4613f19b376bc470ca19398a264b6132ea2a194047b4b14618199087b",
+      "bytes": 30111
     },
     {
       "path": "skills/story-long-analyze/references/deconstruction-notes.md",
@@ -204,8 +204,8 @@
     },
     {
       "path": "skills/story-long-scan/SKILL.md",
-      "sha256": "faac5fccf052dcbcb49ca26315977424e9a662f2eed80d6c5fd19eba7f765d55",
-      "bytes": 16432
+      "sha256": "aedbfc25b66d525a08a806554a6aeb51eb2d3cf5a9ef6647a20a25d3b276e2c8",
+      "bytes": 16430
     },
     {
       "path": "skills/story-long-scan/references/genre-trends.md",
@@ -264,8 +264,8 @@
     },
     {
       "path": "skills/story-long-write/SKILL.md",
-      "sha256": "1bd0991c4054a280f49abb0d2cec26fc74582851e19f34e5b397abd4ef7a9f17",
-      "bytes": 27252
+      "sha256": "1a0dc6b6e3faed84d0c0ddea4e541613f0a22004c1bd9be4be6271c16324f358",
+      "bytes": 27250
     },
     {
       "path": "skills/story-long-write/references/anti-ai-writing.md",
@@ -669,8 +669,8 @@
     },
     {
       "path": "skills/story-review/SKILL.md",
-      "sha256": "7292e49968309050a26617f2037cd0ec1d1301b9fe9676e2006ff87c404e0c8b",
-      "bytes": 38654
+      "sha256": "3a4f4c4b9ada336f3a1dc0df6e9b0e51414ce59aefbf8bfff56ccf9ae22cd40d",
+      "bytes": 38652
     },
     {
       "path": "skills/story-review/references/anti-ai-writing.md",
@@ -749,8 +749,8 @@
     },
     {
       "path": "skills/story-setup/SKILL.md",
-      "sha256": "ecd2216e803c771a00b322f32f6782cb719a35ee9814ccd296f1576b33b0b415",
-      "bytes": 51900
+      "sha256": "106d4ed2364b3d7e46c63d1fa1cc66c348ef42e428f3690c414c35f912cb7ce4",
+      "bytes": 51896
     },
     {
       "path": "skills/story-setup/references/agent-references/anti-ai-writing.md",
@@ -1044,8 +1044,8 @@
     },
     {
       "path": "skills/story-short-analyze/SKILL.md",
-      "sha256": "be345bfd3731e7eafc846a3922628d1ba52febb7dd6b1ebde1c77b47c6e8e396",
-      "bytes": 17011
+      "sha256": "da56247c85ae43d85d39ab905101522b99a0147923b33e8a64acf668cd5e6e98",
+      "bytes": 17009
     },
     {
       "path": "skills/story-short-analyze/references/anti-ai-writing.md",
@@ -1149,8 +1149,8 @@
     },
     {
       "path": "skills/story-short-scan/SKILL.md",
-      "sha256": "ae9563681b649e8c03cea39c8e508587dc410b3e797dffda7b020d55450de7e3",
-      "bytes": 8991
+      "sha256": "def39be0868b47260e9ed4101bceac32a7582b63c903b8efb98514021e835f8a",
+      "bytes": 8989
     },
     {
       "path": "skills/story-short-scan/references/real-market-data.md",
@@ -1174,8 +1174,8 @@
     },
     {
       "path": "skills/story-short-write/SKILL.md",
-      "sha256": "bc9e649f00da62cae39887b3a82d9ec47bea93ebefeabaa3e12f7efb71173fef",
-      "bytes": 36117
+      "sha256": "2dc4fca047754bf1ed1db63a556a78d26a0e6cb4c27e11281a9da803e0214957",
+      "bytes": 36115
     },
     {
       "path": "skills/story-short-write/references/banned-words.md",
@@ -1339,8 +1339,8 @@
     },
     {
       "path": "skills/story/SKILL.md",
-      "sha256": "ee6af57e46d2b2a29ca1e760f566b32360388baa1c12dd656cb31cf8bff7183f",
-      "bytes": 9598
+      "sha256": "da0a5f7bc35b0d838b3e28b271a353065bb0e9ba043b13d64be226be282c1fbc",
+      "bytes": 9584
     },
     {
       "path": "skills/story/VERSION",

--- a/packages/knowledge/oh-story/skills/browser-cdp/SKILL.md
+++ b/packages/knowledge/oh-story/skills/browser-cdp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: browser-cdp
 description: "Use this skill when you need to control a Chrome browser via CDP (Chrome DevTools Protocol) to reuse existing login sessions. Covers: launching Chrome in debug mode, opening URLs, waiting for page load, evaluating JavaScript, taking snapshots, and extracting auth tokens. Trigger phrases: browser automation, CDP, agent-browser, 浏览器操作, 操作浏览器, Chrome CDP, 复用登录态, extract token from browser."
-metadata: {"openclaw":{"requires":{"bins":["agent-browser"]},"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"requires":{"bins":["agent-browser"]},"source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # Browser CDP 操作工具
 

--- a/packages/knowledge/oh-story/skills/story-cover/SKILL.md
+++ b/packages/knowledge/oh-story/skills/story-cover/SKILL.md
@@ -2,7 +2,7 @@
 name: story-cover
 version: 1.0.0
 description: "小说封面生成。根据书名、作者名自动分析题材风格，调用 GPT-Image-2 生成含标题和署名的专业级网文封面；Codex CLI 优先使用内置 ImageGen，无需单独 API Key。触发方式：/story-cover、/封面、「帮我做个封面」「生成封面图」「做个小说封面」「封面设计」。"
-metadata: {"openclaw":{"requires":{"env":["GPT_IMAGE_API_KEY"],"bins":["curl","jq","base64"]},"primaryEnv":"GPT_IMAGE_API_KEY","source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"requires":{"env":["GPT_IMAGE_API_KEY"],"bins":["curl","jq","base64"]},"primaryEnv":"GPT_IMAGE_API_KEY","source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # story-cover：小说封面生成
 

--- a/packages/knowledge/oh-story/skills/story-deslop/SKILL.md
+++ b/packages/knowledge/oh-story/skills/story-deslop/SKILL.md
@@ -2,7 +2,7 @@
 name: story-deslop
 version: 1.0.0
 description: "网文去AI味。检测并清除文本中的AI写作痕迹，让文字回归自然、非模板化。触发方式：/story-deslop、/去AI味、「去AI味」「这篇太AI了」「网文去AI味」。"
-metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # story-deslop：网文去AI味
 

--- a/packages/knowledge/oh-story/skills/story-import/SKILL.md
+++ b/packages/knowledge/oh-story/skills/story-import/SKILL.md
@@ -2,7 +2,7 @@
 name: story-import
 version: 1.0.0
 description: "逆向导入已有小说。将已写好的小说（半成品或完本）反向解析为标准项目目录结构，兼容 story-long-write / story-short-write 后续写作流程；内部复用 story-long-analyze / story-short-analyze 的拆解管道，按篇幅自动分流。触发方式：/story-import、「导入小说」「反向解析」「导入」「把我的书导进来」。"
-metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # story-import：逆向导入已有小说
 

--- a/packages/knowledge/oh-story/skills/story-long-analyze/SKILL.md
+++ b/packages/knowledge/oh-story/skills/story-long-analyze/SKILL.md
@@ -2,7 +2,7 @@
 name: story-long-analyze
 version: 1.0.0
 description: "长篇网文拆文。深度拆解爆款长篇小说的黄金三章、人设架构、爽点设计、节奏控制。单一深度拆解管道：跑完黄金三章（Stage 1）后产出快速预览报告并询问是否继续全量拆解，确认后从 Stage 2 续跑逐章摘要、聚合分析、设定关系、汇总报告，全程产物落盘 拆文库/{书名}/。触发方式：/story-long-analyze、/长篇拆文、「帮我拆这本书」「拆这本书」「分析黄金三章」「深度拆解」「完整拆解」「系统拆解」或提供小说文本文件路径——全部进入同一管道。"
-metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # story-long-analyze：长篇网文拆文
 

--- a/packages/knowledge/oh-story/skills/story-long-scan/SKILL.md
+++ b/packages/knowledge/oh-story/skills/story-long-scan/SKILL.md
@@ -2,7 +2,7 @@
 name: story-long-scan
 version: 1.0.0
 description: "长篇网文扫榜。分析起点、番茄、晋江等平台排行榜数据，提炼市场趋势与热门题材。触发方式：/story-long-scan、/长篇扫榜、「长篇什么火」「起点排行」。"
-metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # story-long-scan：长篇网文扫榜
 

--- a/packages/knowledge/oh-story/skills/story-long-write/SKILL.md
+++ b/packages/knowledge/oh-story/skills/story-long-write/SKILL.md
@@ -2,7 +2,7 @@
 name: story-long-write
 version: 1.0.0
 description: "长篇网文写作。从大纲到正文，辅助长篇网络小说的创作，包括世界观、人物、情节线管理。触发方式：/story-long-write、/写长篇、「帮我开书」「写大纲」「日更」「续写」「继续写」「修改第X章」「回炉」「重写第X章」。"
-metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # story-long-write：长篇网文写作
 

--- a/packages/knowledge/oh-story/skills/story-review/SKILL.md
+++ b/packages/knowledge/oh-story/skills/story-review/SKILL.md
@@ -2,7 +2,7 @@
 name: story-review
 version: 1.1.1
 description: "多视角对抗式审查。full/lean 模式在已部署 reviewer agents 时并行 spawn；缺失/异常 agents 或 spawn 失败时自动降级 solo，参考文件不可读时使用内置 rubric fallback。触发方式：/story-review、/审查、「审查一下」「帮我审一下」。"
-metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # story-review：多视角对抗式审查
 

--- a/packages/knowledge/oh-story/skills/story-setup/SKILL.md
+++ b/packages/knowledge/oh-story/skills/story-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: story-setup
 version: 1.2.7
 description: "网文写作工具集基础设施部署。为 Claude Code / OpenCode / Codex / ZCode / OpenClaw / Reasonix 提供内置适配；Web AI / 通用 Agent 可走 skills + AGENTS.md 文件模式。触发方式：/story-setup、$story-setup、「准备写书」「帮我搭一下环境」「配置写作项目」。"
-metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # story-setup：网文写作工具集基础设施部署
 
@@ -14,7 +14,7 @@ metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claud
 
 ## Phase 1：检测项目状态
 
-**先自检参考目录**：以正在执行的本 `SKILL.md` 所在目录为准，列出与它同级的 `references/` 下的子目录，核对下面 8 个名字是否都在**且都非空**——`agent-references`、`templates`、`opencode`、`codex`、`zcode`、`openclaw`、`reasonix`、`generic`；同级 `scripts/merge-claude-settings.py`、`scripts/merge-codex-hooks.py` 与 `scripts/copy-path-safety.py` 也必须存在（Claude/Codex hooks 合并和递归复制安全检查依赖它们）。有缺即 skill 包没装全，**立即停止，不写任何部署文件**，报告里区分「缺目录」「目录为空」和「缺脚本」，并给修复指令：「story-setup 参考资料包不完整，缺 {路径}。按你的安装方式重装 oh-story-claudecode（命令行装的重跑 `npx skills add worldwonderer/oh-story-claudecode -y -g`，marketplace / Plugin Management 装的在面板里重装），再执行 /story-setup。」
+**先自检参考目录**：以正在执行的本 `SKILL.md` 所在目录为准，列出与它同级的 `references/` 下的子目录，核对下面 8 个名字是否都在**且都非空**——`agent-references`、`templates`、`opencode`、`codex`、`zcode`、`openclaw`、`reasonix`、`generic`；同级 `scripts/merge-claude-settings.py`、`scripts/merge-codex-hooks.py` 与 `scripts/copy-path-safety.py` 也必须存在（Claude/Codex hooks 合并和递归复制安全检查依赖它们）。有缺即 skill 包没装全，**立即停止，不写任何部署文件**，报告里区分「缺目录」「目录为空」和「缺脚本」，并给修复指令：「story-setup 参考资料包不完整，缺 {路径}。按你的安装方式重装 oh-story-claudecode（命令行装的重跑 `npx skills add zenstory-ai/oh-story-claudecode -y -g`，marketplace / Plugin Management 装的在面板里重装），再执行 /story-setup。」
 
 > 判据是「有没有 `SKILL.md`」：只看正在执行的 `SKILL.md` 同级的 `references/`。项目内 `.claude/skills/story-setup/`、`.codex/skills/story-setup/` 和 OpenCode 的 `skills/story-setup/` 只有 `references/agent-references/`、不含 `SKILL.md`，不会是执行目录，也不要拿它们核对。ZCode / OpenClaw / Reasonix / generic 的项目副本是整份 skill 拷贝、自带 `SKILL.md`，8 个子目录本就齐全，照常核对即可。
 

--- a/packages/knowledge/oh-story/skills/story-short-analyze/SKILL.md
+++ b/packages/knowledge/oh-story/skills/story-short-analyze/SKILL.md
@@ -2,7 +2,7 @@
 name: story-short-analyze
 version: 3.0.0
 description: "短篇网文拆文。拆解爆款短篇小说（番茄短篇 / 故事会 / 知乎盐选 / 追妻 / 世情 / 重生 / 虐渣等通俗题材）的故事核、结构、情感线、反转设计、写作手法、共鸣层次。单一全量拆解管道：跑完 Stage 2-6 产出完整拆文报告，落盘到 拆文库/{书名}/，下游 story-short-write 同时读拆文报告 + 情节节点 + 写作手法 + 原文 + _meta.json 写下一篇。触发方式：/story-short-analyze、/短篇拆文、「拆短篇」「拆这篇短文」「短篇拆文」「精细拆解短篇」「8000 字短篇拆解」「番茄短篇拆文」「故事会拆解」「盐言故事拆解」「分析这篇短篇」——均进入同一管道。"
-metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # story-short-analyze：短篇网文拆文
 

--- a/packages/knowledge/oh-story/skills/story-short-scan/SKILL.md
+++ b/packages/knowledge/oh-story/skills/story-short-scan/SKILL.md
@@ -2,7 +2,7 @@
 name: story-short-scan
 version: 1.0.0
 description: "短篇网文扫榜。分析知乎盐言、七猫、黑岩、点众等平台热门短篇数据，捕捉风口题材。触发方式：/story-short-scan、/短篇扫榜、「短篇什么火」「知乎故事排行」。"
-metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # story-short-scan：短篇网文扫榜
 

--- a/packages/knowledge/oh-story/skills/story-short-write/SKILL.md
+++ b/packages/knowledge/oh-story/skills/story-short-write/SKILL.md
@@ -2,7 +2,7 @@
 name: story-short-write
 version: 1.0.0
 description: "短篇网文写作。辅助短篇小说创作，从构思到成稿，聚焦情绪拉扯与节奏把控。触发方式：/story-short-write、/写短篇、「帮我写一篇短篇」「写个盐言故事」。"
-metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # story-short-write：短篇网文写作
 

--- a/packages/knowledge/oh-story/skills/story/SKILL.md
+++ b/packages/knowledge/oh-story/skills/story/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: story
 description: "网络小说工具箱主入口。根据用户需求自动路由到对应 skill，并可启动本地 Dashboard 查看拆文库、写作项目和编辑文本。触发方式：/story、$story、/story dashboard、$story dashboard、/网文、「我想写小说」「打开工作台」「检查更新」。"
-metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claudecode"}}
+metadata: {"openclaw":{"source":"https://github.com/zenstory-ai/oh-story-claudecode"}}
 ---
 # story：网文工具箱路由
 
@@ -107,10 +107,10 @@ metadata: {"openclaw":{"source":"https://github.com/worldwonderer/oh-story-claud
 用户问"有没有新版本""检查更新""升级"时执行。**只通知，更不更新由用户定，不自动安装。**
 
 1. **当前版本**：读本 skill 同目录的 `VERSION` 文件；缺失则视为未知。
-2. **最新版本**：优先 `gh release view --json tagName,name,url -R worldwonderer/oh-story-claudecode` 取 `tagName`；无 gh 用 `curl -fsS --max-time 5 https://api.github.com/repos/worldwonderer/oh-story-claudecode/releases/latest` 取 `.tag_name`（jq 或 grep）。查不到 → 告知"暂时拉不到最新版本，可手动看 [Releases](https://github.com/worldwonderer/oh-story-claudecode/releases)"，不报错。
+2. **最新版本**：优先 `gh release view --json tagName,name,url -R zenstory-ai/oh-story-claudecode` 取 `tagName`；无 gh 用 `curl -fsS --max-time 5 https://api.github.com/repos/zenstory-ai/oh-story-claudecode/releases/latest` 取 `.tag_name`（jq 或 grep）。查不到 → 告知"暂时拉不到最新版本，可手动看 [Releases](https://github.com/zenstory-ai/oh-story-claudecode/releases)"，不报错。
 3. **比较**：去掉 `v` 前缀按语义版本比（major.minor.patch）。`gh release` 默认取 latest 稳定版，不含 pre-release。
 4. **告知**：
    - 已最新 → 「已是最新版 vX.Y.Z」。
-   - 有新版 → 列出 当前 vA → 最新 vB + [Releases](https://github.com/worldwonderer/oh-story-claudecode/releases)/[CHANGELOG](https://github.com/worldwonderer/oh-story-claudecode/blob/main/CHANGELOG.md)（能拿到 release notes 就附本次要点），再用 AskUserQuestion 问「现在更新吗？」：
-     - 选更新 → 跑 `npx skills add worldwonderer/oh-story-claudecode -y -g`（`-g` 全局，去掉则只更当前目录）；完成后提示：已部署过的项目在项目根重跑 `/story-setup`（Codex 中用 `$story-setup`）同步 hooks/agents/references，并**新开一个会话**让 agents 重新注册。
+   - 有新版 → 列出 当前 vA → 最新 vB + [Releases](https://github.com/zenstory-ai/oh-story-claudecode/releases)/[CHANGELOG](https://github.com/zenstory-ai/oh-story-claudecode/blob/main/CHANGELOG.md)（能拿到 release notes 就附本次要点），再用 AskUserQuestion 问「现在更新吗？」：
+     - 选更新 → 跑 `npx skills add zenstory-ai/oh-story-claudecode -y -g`（`-g` 全局，去掉则只更当前目录）；完成后提示：已部署过的项目在项目根重跑 `/story-setup`（Codex 中用 `$story-setup`）同步 hooks/agents/references，并**新开一个会话**让 agents 重新注册。
      - 选先不 → 不动，告知随时可再来。

--- a/scripts/demo-fixtures/sources.json
+++ b/scripts/demo-fixtures/sources.json
@@ -3,15 +3,15 @@
   "fixtures": [
     {
       "kind": "story",
-      "repository": "https://github.com/worldwonderer/oh-story-claudecode",
-      "commit": "9d0bd5f5aead707ddcdcf7d5f141b237e2ac464c",
+      "repository": "https://github.com/zenstory-ai/oh-story-claudecode",
+      "commit": "a78f75a234f084c6b5469b301eecbea103c1ecae",
       "sourcePath": "demo/长篇/让你管账号，你高燃混剪炸全网",
       "localPath": "story/让你管账号，你高燃混剪炸全网"
     },
     {
       "kind": "drama",
-      "repository": "https://github.com/worldwonderer/drama-skills",
-      "commit": "7811065c171f8b0a83230bb2e0ccfe2c2b5b337a",
+      "repository": "https://github.com/zenstory-ai/drama-skills",
+      "commit": "db69caa238ee1dab5514589319a83f0778e6b4db",
       "sourcePath": "examples/creator-first/EP001",
       "localPath": "drama/让你管账号/剧集/EP001",
       "files": [


### PR DESCRIPTION
## Summary
- migrate DSH repository, release, package metadata, and security links to `zenstory-ai/oh-story-dsh`
- pin bundled Oh Story and Drama provenance to their approved migrated SHAs
- regenerate only the upstream manifests and embedded namespace-bearing skill files
- preserve personal copyright attribution and package version

## Verification
- registered patch head: `aa91bbd8900073e1bb56786fb2782ebe2e2c8db6`
- `pnpm assets:check`, `verify`, `verify:portable`, and `verify:release` passed
- packed `oh-story-dsh-0.1.4.tgz` successfully

No npm publish is performed by this PR.
