### PR TITLE
docs(changelog): 采用组织统一的发布标准

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-本文件记录 `@oh-story/dsh` 的用户可见变更。版本遵循 [Semantic Versioning](https://semver.org/)。
+本文件记录 `@oh-story/dsh` 的用户可见变更。
+
+格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
+版本号遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)。
+
+小节名使用 Keep a Changelog 的六个英文类别（`Added` / `Changed` / `Deprecated` /
+`Removed` / `Fixed` / `Security`），正文为中文。收紧到会拒绝旧输入的改动记入 `Changed`。
+同步上游时写清上游版本号与提交，便于定位。
 
 ## [Unreleased]
 


### PR DESCRIPTION
按 [zenstory-ai/.github 的 `release-writing` skill](https://github.com/zenstory-ai/.github/tree/main/skills/release-writing) 对齐组织标准。

本仓库此前已经很接近：英文小节名、方括号版本标题、底部 compare 链接都在。

头部补三句：

- 补 **Keep a Changelog** 声明（六个类别的出处）
- 写明**收紧到会拒绝旧输入的记入 `Changed`**——这条判错的代价不对称，记宽了只是多看一眼，记窄了会让人在生产环境撞墙
- 把本仓库**已经在做**的约定写下来：同步上游时写清上游版本号与提交，便于定位

既有条目一律不动。

## 后续（不在本 PR）

5 个 release 标题是 `oh-story-dsh v0.1.4` 这种形式，没有主题词，列表里看不出哪版该看，建议按 `vX.Y.Z — 主题` 补。往期 release notes 里 5 处旧命名空间链接**已直接修正**。