### PR TITLE
docs: document dedicated-profile install for on-demand loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,41 @@ npx -y @deepseek-ai/dsh@0.1.1-rc.1 web
 
 添加作品目录为 workspace，新建或打开 Session 后使用 `/story` 或 `/short-drama`。小说与短剧工作台可随时通过左栏 Tab 切换。
 
+## 按需加载
+
+插件装进哪个 profile，那个 profile 的每个 Session 就都会加载创作 Skills 与三栏工作台。想让原版 `web` 保持干净、只在创作时打开工作台，就把插件装进独立 profile。
+
+**1. 装进独立 profile**
+
+```bash
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile story add @oh-story/dsh@0.1.4
+```
+
+**2. 补上界面**
+
+新 profile 默认没有界面。编辑 `~/.dsh/profiles/story/package.json`，把 `dsh.profile.bundles` 改成：
+
+```jsonc
+"bundles": [
+  "@deepseek-ai/dsh-base",
+  "@deepseek-ai/dsh-web-app",
+  "@oh-story/dsh"
+]
+```
+
+顺序照抄，这个包不用另外安装。
+
+**3. 按需启动**
+
+```bash
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 web                          # 原版 DSH
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 --profile story --port 3081  # 创作工作台
+```
+
+两个 profile 用不同端口可以同时运行。模型、凭据、workspace 与历史会话由 DSH 统一保存，切换 profile 不会丢。
+
+安装与启动请使用同一个 dsh 版本；混用会报 `unknown option '--no-open'` 一类的错。
+
 ## 致谢
 
 - [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)：提供原生插件运行时、Agent、会话、权限审批与 Web 工作台基础。

--- a/packages/dsh-plugin/README.md
+++ b/packages/dsh-plugin/README.md
@@ -35,6 +35,23 @@ npx -y @deepseek-ai/dsh@0.1.1-rc.1 web
 
 Drama Skills 0.6.0 不支持把 v0.5 结构化项目原地升级为 creator-first 项目。旧项目应继续锁定 v0.5 并只读保留；迁移时请新建项目根，逐集人工确认当前工作实际需要的 `剧本.md`、`视觉设定.md`、`分镜.md`、`图片提示词.md` 或 `视频提示词.md`，不要预建空文档。
 
+## 按需加载
+
+插件装进哪个 profile，那个 profile 的每个 Session 就都会加载创作 Skills 与三栏工作台。想让原版 `web` 保持干净、只在创作时打开工作台，就装进独立 profile：
+
+```bash
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 plugin --profile story add @oh-story/dsh@0.1.4
+```
+
+新 profile 默认没有界面。编辑 `~/.dsh/profiles/story/package.json`，把 `dsh.profile.bundles` 改成 `["@deepseek-ai/dsh-base", "@deepseek-ai/dsh-web-app", "@oh-story/dsh"]`，顺序照抄，这个包不用另外安装。
+
+```bash
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 web                          # 原版 DSH
+npx -y @deepseek-ai/dsh@0.1.1-rc.1 --profile story --port 3081  # 创作工作台
+```
+
+模型、凭据、workspace 与历史会话由 DSH 统一保存，切换 profile 不会丢。安装与启动请使用同一个 dsh 版本。
+
 ## License
 
 [Changelog](https://github.com/zenstory-ai/oh-story-dsh/blob/main/CHANGELOG.md) · [MIT](LICENSE)


### PR DESCRIPTION
## 背景

常见用户提问：只想在写小说时加载插件，平时用原版 DSH 界面。

插件在 profile 内是全局注册的（`packages/dsh-plugin/src/index.ts:38-39` 无条件 `registerProvider`），装进哪个 profile，该 profile 的每个 Session 都会加载全部 Skills 与三栏工作台，没有按会话开关。因此切换只能发生在启动层，而 DSH 的 profile 正是为此设计的。

## 变更

README 与插件包 README 各新增「按需加载」一节：装进独立 profile、补上浏览器界面层、按需启动。

关键一步是第 2 步：DSH 只为 `web` 与 `headless` 内置模板（`PROFILE_TEMPLATES`），其它名字初始化时只有 `@deepseek-ai/dsh-base`，**没有浏览器界面**。用户必须手动把 `@deepseek-ai/dsh-web-app` 写进 `dsh.profile.bundles`。不写清楚的话，照着 `dsh plugin --profile story add` 做完会得到一个起不来界面的 profile。

## 验证

在隔离的 `DSH_HOME` 中用 `@deepseek-ai/dsh@0.1.1-rc.1` 实测全流程：

- `dsh plugin --profile story add` 后 `bundles` 为 `["@deepseek-ai/dsh-base", "@oh-story/dsh"]`，确认缺少界面层。
- 手动补上 `@deepseek-ai/dsh-web-app` 后，`dsh --profile story --help` 输出 Web app 自己的 `--host / --no-open / --port / --trusted-host`。
- `dsh --profile story --no-open --port 3183` 启动，根路径 HTTP 200。
- 服务端插件路由生效：`/oh-story` 由插件自身 handler 应答（`{"error":"Oh Story route not found."}`），而非 Web server 的空 body 404。
- 客户端资源生效：boot payload 含 `{"id":"@oh-story/dsh","url":"/plugins/@oh-story/dsh/client.js?rev=..."}`，该 URL 返回 HTTP 200 / 84285 bytes。
- `@deepseek-ai/dsh-web-app` 未装进 profile 的 `dependencies`，仅写入 `bundles` 即生效，确认「不需要另外安装」。

版本一致性提示也来自实测：误用缓存中的旧版 dsh 会报 `error: unknown option '--no-open'`。

`pnpm verify` 通过（lint、typecheck、assets parity、DSH boundary、41 单测、build）。

## 说明

- 纯文档变更，未改动 CHANGELOG，与 `09a9362 docs: migrate repository namespace` 的先例一致。这里记录的是 DSH 既有行为的使用方式，不是 `@oh-story/dsh` 的用户可见变更。如果希望也进 `[Unreleased]`，我可以补。
- 另有两种同 profile 内的开关方案（`--patch` 覆盖层、`!!js process.env` 门控 `disabled`）也实测可行，但隔离性弱于独立 profile，本 PR 未写入文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJcNrdvSQM9PruLWqG1YHi
