### PR TITLE
release: prepare v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-09-02
+
 ### Fixed
 
 - 长答复不再在窗口尺寸变化后躲到 Composer 后面（[#26](https://github.com/zenstory-ai/oh-story-dsh/issues/26)）。工作台把 Composer 座位叠在 Chat 列上，所以「读者被挤出尾部」不只是滚动位置不对，最后几行会直接落在输入框后面。此前贴底判定在 ResizeObserver 回调里现算，而那时 Chat 已经重排完，判定必然是「没贴底」；现在贴底状态只由用户自己的滚动（滚轮、触摸、拖动、非输入框按键）释放，布局引起的滚动不改它，滚到底则重新取回。同时把 Chat 正文纳入尺寸观察：窗口变化后正文还要重排几帧，每次回落都重新贴底，不再停在第一帧的瞬时高度上。
@@ -156,7 +158,8 @@
 - 提供 13 个 Oh Story 小说 Skills、7 个专业 Roles 与 10 个 Drama Skills。
 - 提供文件树、Markdown/JSONL 编辑预览与官方 DSH Chat 同屏的三栏工作台。
 
-[Unreleased]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.2...v0.1.3

--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@
 **1. 安装插件并启动 DSH Web**
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile web add @oh-story/dsh@0.1.5
+npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile web add @oh-story/dsh@0.1.6
 npx -y @deepseek-ai/dsh@0.1.2-alpha.3 web
 ```
 
 也可以直接安装 GitHub Release 中经过同一套测试的预构建包：
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile web add https://github.com/zenstory-ai/oh-story-dsh/releases/download/v0.1.5/oh-story-dsh-0.1.5.tgz
+npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile web add https://github.com/zenstory-ai/oh-story-dsh/releases/download/v0.1.6/oh-story-dsh-0.1.6.tgz
 npx -y @deepseek-ai/dsh@0.1.2-alpha.3 web
 ```
 
@@ -97,7 +97,7 @@ npx -y @deepseek-ai/dsh@0.1.2-alpha.3 web
 **1. 装进独立 profile**
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile story add @oh-story/dsh@0.1.5
+npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile story add @oh-story/dsh@0.1.6
 ```
 
 **2. 补上界面**

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,7 +43,7 @@ safely re-run.
 Do not announce a release until the registry reports the exact version:
 
 ```bash
-VERSION=0.1.5
+VERSION=0.1.6
 npm view "@oh-story/dsh@$VERSION" version dist.integrity
 npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile web add "@oh-story/dsh@$VERSION"
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-story-dsh",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "A DSH plugin for fiction, short-drama, playable game, and video-recap production",
   "license": "MIT",

--- a/packages/dsh-plugin/README.md
+++ b/packages/dsh-plugin/README.md
@@ -21,14 +21,14 @@
 ## 安装
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile web add @oh-story/dsh@0.1.5
+npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile web add @oh-story/dsh@0.1.6
 npx -y @deepseek-ai/dsh@0.1.2-alpha.3 web
 ```
 
 也可以直接安装 GitHub Release 中的预构建包：
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile web add https://github.com/zenstory-ai/oh-story-dsh/releases/download/v0.1.5/oh-story-dsh-0.1.5.tgz
+npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile web add https://github.com/zenstory-ai/oh-story-dsh/releases/download/v0.1.6/oh-story-dsh-0.1.6.tgz
 npx -y @deepseek-ai/dsh@0.1.2-alpha.3 web
 ```
 
@@ -67,7 +67,7 @@ Drama Skills 0.6.0 不支持把 v0.5 结构化项目原地升级为 creator-firs
 插件装进哪个 profile，那个 profile 的每个 Session 就都会加载创作 Skills 与三栏工作台。想让原版 `web` 保持干净、只在创作时打开工作台，就装进独立 profile：
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile story add @oh-story/dsh@0.1.5
+npx -y @deepseek-ai/dsh@0.1.2-alpha.3 plugin --profile story add @oh-story/dsh@0.1.6
 ```
 
 新 profile 默认没有界面。编辑 `~/.dsh/profiles/story/package.json`，把 `dsh.profile.bundles` 改成 `["@deepseek-ai/dsh-base", "@deepseek-ai/dsh-web-app", "@oh-story/dsh"]`，顺序照抄，这个包不用另外安装。

--- a/packages/dsh-plugin/package.json
+++ b/packages/dsh-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-story/dsh",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A DSH plugin for fiction, short-drama, interactive-game, and video-recap production",
   "keywords": [
     "deepseek-harness",


### PR DESCRIPTION
补丁版，只含 [#26](https://github.com/zenstory-ai/oh-story-dsh/issues/26) 的修复（[#27](https://github.com/zenstory-ai/oh-story-dsh/pull/27)）：长答复的尾部不再在滚动区域尺寸变化后落到 Composer 后面。

## 改了什么

- `CHANGELOG.md`：`## [Unreleased]` 下的 Fixed 切成 `## [0.1.6] - 2026-09-02`，补 `[0.1.6]` 版本链接。
- 根包与 `@oh-story/dsh` 的 `version`、两份 README 的三处安装示例、`docs/RELEASING.md` 的 `VERSION=` 升到 0.1.6。

随包的四套上游 Skills 与 0.1.5 相同（Oh Story 0.7.9、Drama Skills 0.6.4、NovelToGame 0.3.0、video-recap-skills 0.4.0），没有项目文件或目录变更。

## 验证

`pnpm verify:release` 本地全绿（lint、typecheck、四套上游 parity、DSH boundary、84 单测、build，以及打包插件 + 官方 DSH Web + 真 Chrome 的完整 E2E）。

合并后打 `v0.1.6` 标签触发发布工作流。

🤖 Generated with [Claude Code](https://claude.com/claude-code)