### PR TITLE
release: prepare v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-09-04
+
 ### Changed
 
 - 工作台不再接管每一次会话（[#29](https://github.com/zenstory-ai/oh-story-dsh/issues/29)）。DSH 是通用 Harness，而此前只要装上插件，任何 Session 都会被改成三栏（游戏/视频为两栏）布局，官方 Chat 被压到右侧且无法关闭，写代码或普通对话时同样如此。现在只有当前 workspace 真的存在小说、短剧、游戏或视频项目时才接管布局；随包的《金瓶梅》示例不算作 workspace 创作项目。没有创作项目时插件在界面上完全不出现，会话由 DSH 原样渲染，`Ctrl/Cmd+S` 与 Chat 里的文件名点击也不再被工作台接管。Agent 写出第一个创作文件（例如 `/story-setup`）后，工作台会在同一次会话里自动出现。
@@ -171,7 +173,8 @@
 - 提供 13 个 Oh Story 小说 Skills、7 个专业 Roles 与 10 个 Drama Skills。
 - 提供文件树、Markdown/JSONL 编辑预览与官方 DSH Chat 同屏的三栏工作台。
 
-[Unreleased]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.6...HEAD
+[Unreleased]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.7...HEAD
+[0.1.7]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/zenstory-ai/oh-story-dsh/compare/v0.1.3...v0.1.4

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@
 **1. 安装插件并启动 DSH Web**
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add @oh-story/dsh@0.1.6
+npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add @oh-story/dsh@0.1.7
 npx -y @deepseek-ai/dsh@0.1.2-rc.1 web
 ```
 
 也可以直接安装 GitHub Release 中经过同一套测试的预构建包：
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add https://github.com/zenstory-ai/oh-story-dsh/releases/download/v0.1.6/oh-story-dsh-0.1.6.tgz
+npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add https://github.com/zenstory-ai/oh-story-dsh/releases/download/v0.1.7/oh-story-dsh-0.1.7.tgz
 npx -y @deepseek-ai/dsh@0.1.2-rc.1 web
 ```
 
@@ -119,7 +119,7 @@ npx -y @deepseek-ai/dsh@0.1.2-rc.1 web
 **1. 装进独立 profile**
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile story add @oh-story/dsh@0.1.6
+npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile story add @oh-story/dsh@0.1.7
 ```
 
 **2. 补上界面**

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,7 +43,7 @@ safely re-run.
 Do not announce a release until the registry reports the exact version:
 
 ```bash
-VERSION=0.1.6
+VERSION=0.1.7
 npm view "@oh-story/dsh@$VERSION" version dist.integrity
 npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add "@oh-story/dsh@$VERSION"
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-story-dsh",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "description": "A DSH plugin for fiction, short-drama, playable game, and video-recap production",
   "license": "MIT",

--- a/packages/dsh-plugin/README.md
+++ b/packages/dsh-plugin/README.md
@@ -21,14 +21,14 @@
 ## 安装
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add @oh-story/dsh@0.1.6
+npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add @oh-story/dsh@0.1.7
 npx -y @deepseek-ai/dsh@0.1.2-rc.1 web
 ```
 
 也可以直接安装 GitHub Release 中的预构建包：
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add https://github.com/zenstory-ai/oh-story-dsh/releases/download/v0.1.6/oh-story-dsh-0.1.6.tgz
+npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add https://github.com/zenstory-ai/oh-story-dsh/releases/download/v0.1.7/oh-story-dsh-0.1.7.tgz
 npx -y @deepseek-ai/dsh@0.1.2-rc.1 web
 ```
 
@@ -69,7 +69,7 @@ Drama Skills 0.6.0 不支持把 v0.5 结构化项目原地升级为 creator-firs
 插件装进哪个 profile，那个 profile 的每个 Session 就都会加载创作 Skills 与三栏工作台。想让原版 `web` 保持干净、只在创作时打开工作台，就装进独立 profile：
 
 ```bash
-npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile story add @oh-story/dsh@0.1.6
+npx -y @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile story add @oh-story/dsh@0.1.7
 ```
 
 新 profile 默认没有界面。编辑 `~/.dsh/profiles/story/package.json`，把 `dsh.profile.bundles` 改成 `["@deepseek-ai/dsh-base", "@deepseek-ai/dsh-web-app", "@oh-story/dsh"]`，顺序照抄，这个包不用另外安装。

--- a/packages/dsh-plugin/package.json
+++ b/packages/dsh-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-story/dsh",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A DSH plugin for fiction, short-drama, interactive-game, and video-recap production",
   "keywords": [
     "deepseek-harness",


### PR DESCRIPTION
把 `Unreleased` 归入 `0.1.7`（2026-09-04）。这一版三件事：

- **工作台只在需要时出现**（[#29](https://github.com/zenstory-ai/oh-story-dsh/issues/29)，#30）：workspace 里真有小说、短剧、游戏或视频项目才接管布局，并且随时可以收起。
- **短剧生产说清楚媒体是谁生成的**（#32）：「生产」视图新增「生成环境」条，逐个显示 GPT Image 2、Seedance、MiniMax H3、MiniMax Music 是否已配置；内置 adapter 自动登记到项目外的无凭据配置；README 新增「配置媒体生成 API」。
- **上游升级**：Drama Skills [v0.6.5](https://github.com/zenstory-ai/drama-skills/releases/tag/v0.6.5)（#33，既有项目要给《分镜.md》补两类字段）、DeepSeek Harness 0.1.2-rc.1（#31，旧的 alpha.3 装不上这一版）。

## 改了什么

- `CHANGELOG.md`：`## [Unreleased]` 切成 `## [0.1.7] - 2026-09-04`，补 `[0.1.7]` 版本链接，`[Unreleased]` 链接指向 `v0.1.7...HEAD`。
- 根包与 `@oh-story/dsh` 的 `version`、两份 README 的安装示例、`docs/RELEASING.md` 的 `VERSION=` 升到 0.1.7。

随包的四套上游 Skills：Oh Story 0.7.9、Drama Skills 0.6.5、NovelToGame 0.3.0、video-recap-skills 0.4.0。

## 验证

`pnpm verify:release` 本地全绿：lint、typecheck、四套上游 parity、DSH boundary、104 单测、build，以及打包插件 + 官方 DSH Web 0.1.2-rc.1 + 真 Chrome 的完整 E2E。

合并后打 `v0.1.7` 标签触发发布工作流。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1m8X7Wq2qQm9WmYcd69c9
