### PR TITLE
docs(readme): point ZenStory workbench to app subdomain

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -180,4 +180,4 @@ oh-story-dsh is maintained by [ZenStory AI](https://zenstory.ai) — open-source
 | [novel-to-game](https://github.com/zenstory-ai/novel-to-game) | Agent skills that turn novels into playable games |
 | [video-recap-skills](https://github.com/zenstory-ai/video-recap-skills) | Clip any video into a narrated Chinese recap, with CapCut draft export |
 | [oh-story-dsh](https://github.com/zenstory-ai/oh-story-dsh) | DeepSeek Harness plugin wrapping the Oh Story and Drama Skills workflows (this repo) |
-| [zenstory](https://github.com/zenstory-ai/zenstory) | Chat-to-create AI novel-writing workbench (zenstory.ai) |
+| [zenstory](https://github.com/zenstory-ai/zenstory) | Chat-to-create AI novel-writing workbench ([app.zenstory.ai](https://app.zenstory.ai)) |


### PR DESCRIPTION
## Summary
- link the ZenStory writing workbench to `https://app.zenstory.ai` in the English sibling-project roster
- keep `https://zenstory.ai` as the organization and project-site domain

This reflects the completed domain migration; no runtime behavior or external project is changed.

## Validation
- `pnpm verify` (lint, typecheck, asset checks, boundary checks, 108 unit tests, and build passed)
- `git diff --check`