### PR TITLE
docs: align family summaries with supported workflows

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -177,7 +177,7 @@ oh-story-dsh is maintained by [ZenStory AI](https://zenstory.ai) — open-source
 | --- | --- |
 | [oh-story-claudecode](https://github.com/zenstory-ai/oh-story-claudecode) | Web-fiction writing skill pack: chart scanning, deconstruction, drafting, de-AI-flavor, covers |
 | [drama-skills](https://github.com/zenstory-ai/drama-skills) | AI short-drama / motion-comic suite: scripts, assets, storyboards, image & video prompts, review |
-| [novel-to-game](https://github.com/zenstory-ai/novel-to-game) | Agent skills that turn novels into playable games |
-| [video-recap-skills](https://github.com/zenstory-ai/video-recap-skills) | Clip any video into a narrated Chinese recap, with CapCut draft export |
-| [oh-story-dsh](https://github.com/zenstory-ai/oh-story-dsh) | DeepSeek Harness plugin wrapping the Oh Story and Drama Skills workflows (this repo) |
+| [novel-to-game](https://github.com/zenstory-ai/novel-to-game) | Agent skills for source-grounded novel adaptation, target-runtime builds, and evidence-based QA |
+| [video-recap-skills](https://github.com/zenstory-ai/video-recap-skills) | Create Chinese-narration recaps from supported video files, with optional editable JianYing/CapCut draft export |
+| [oh-story-dsh](https://github.com/zenstory-ai/oh-story-dsh) | Community DeepSeek Harness plugin with novel, short-drama, game and video-recap workbenches (this repo) |
 | [zenstory](https://github.com/zenstory-ai/zenstory) | Chat-to-create AI novel-writing workbench ([app.zenstory.ai](https://app.zenstory.ai)) |


### PR DESCRIPTION
## Summary
- Align owned project discovery descriptions with their existing source contracts: target-runtime builds and evidence-based game QA; supported video inputs with optional editable draft export; DSH community plugin with four workbench scopes.
- Preserve all links, versions, install commands, interfaces, executable code and demo cases. Only three existing family-summary rows per changed README are edited.
- No third-party PRs, registry submission, package release, paid-provider execution or manual deployment/configuration change.

## Source basis
- [Novel build/QA contract](https://github.com/zenstory-ai/novel-to-game/blob/dc013669e18371db105d7e930da9ff9490c55c72/skills/novel-to-game/SKILL.md#L16-L50)
- [Video dependencies and boundaries](https://github.com/zenstory-ai/video-recap-skills/blob/d1c84dd3cbffc4acdb072c330b5b119f6efbb6e1/skills/video-recap/SKILL.md#L47-L69)
- [DSH community identity and scope](https://github.com/zenstory-ai/oh-story-dsh/blob/bbbe456d19139bd901ed4b5390a66fe6453a4fbc/README_EN.md#L9-L17)

## Validation
- Independent native fact/code review approved.
- README-only change; exact changed-line and unchanged-link checks passed. Executable code is unchanged; hosted CI remains the runtime regression gate.
- Root verified exact file/line scope, unchanged README URL sequence, JSON changes confined to existing description fields, and diff whitespace.
- Required exact-head hosted checks will be reviewed before merge. These tests do not establish real-provider/editor behavior, indexing or AI citation growth.
